### PR TITLE
Replace `Vec<IpNet>` with trie `IpTrie` to improve `filter_as_set` bottleneck

### DIFF
--- a/route_policy_cmp/Cargo.lock
+++ b/route_policy_cmp/Cargo.lock
@@ -325,6 +325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ip_network_table-deps-treebitmap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
+
+[[package]]
 name = "ipnet"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +567,7 @@ dependencies = [
  "encoding_rs",
  "encoding_rs_io",
  "env_logger",
+ "ip_network_table-deps-treebitmap",
  "ipnet",
  "itertools",
  "lazy-regex",

--- a/route_policy_cmp/Cargo.toml
+++ b/route_policy_cmp/Cargo.toml
@@ -11,6 +11,7 @@ chardetng = "0.1.17"
 encoding_rs = "0.8.32"
 encoding_rs_io = "0.1.7"
 env_logger = "0.10.0"
+ip_network_table-deps-treebitmap = "0.5.0"
 ipnet = { version = "2.7.2", features = ["serde"] }
 itertools = "0.10.5"
 lazy-regex = "2.5.0"

--- a/route_policy_cmp/src/bgp.rs
+++ b/route_policy_cmp/src/bgp.rs
@@ -4,6 +4,7 @@ pub mod map;
 pub mod peering;
 pub mod query;
 pub mod report;
+pub mod trie;
 pub mod verbosity;
 pub mod wrapper;
 

--- a/route_policy_cmp/src/bgp/filter.rs
+++ b/route_policy_cmp/src/bgp/filter.rs
@@ -146,7 +146,7 @@ impl<'a> CheckFilter<'a> {
             None => return self.skip_any_report(|| SkipReason::AsSetRouteUnrecorded(name.into())),
         };
 
-        if match_ips(&self.compare.prefix, &as_set_route.routes, op) {
+        if as_set_route.routes.match_ip_range(&self.compare.prefix, op) {
             return None;
         }
         let mut aggregator = AnyReportAggregator::new();

--- a/route_policy_cmp/src/bgp/query.rs
+++ b/route_policy_cmp/src/bgp/query.rs
@@ -5,26 +5,25 @@ use rayon::prelude::*;
 
 use crate::parse::{aut_num::AutNum, dump::Dump, set::*};
 
+use super::trie::IpTrie;
+
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct AsSetRoute {
     /// This field should always be sorted.
-    pub routes: Vec<IpNet>,
+    pub routes: IpTrie,
     pub unrecorded_nums: Vec<usize>,
     pub set_members: Vec<String>,
 }
 
 impl AsSetRoute {
     pub fn clean_up(&mut self) {
-        self.routes.sort_unstable();
-        self.routes.dedup();
-        self.routes.shrink_to_fit();
         self.unrecorded_nums.sort_unstable();
         self.unrecorded_nums.dedup();
         self.unrecorded_nums.shrink_to_fit();
     }
 
     pub fn from_as_set(as_set: &AsSet, as_routes: &BTreeMap<usize, Vec<IpNet>>) -> Self {
-        let mut routes = Vec::with_capacity(as_set.members.len() << 2);
+        let mut routes = IpTrie::new();
         let mut unrecorded_nums = Vec::new();
         for member in &as_set.members {
             match as_routes.get(member) {
@@ -50,6 +49,7 @@ pub struct QueryDump {
     pub peering_sets: BTreeMap<String, PeeringSet>,
     pub filter_sets: BTreeMap<String, FilterSet>,
     /// Each value should always be sorted.
+    // TODO: Switch to `IpTrie`.
     pub as_routes: BTreeMap<usize, Vec<IpNet>>,
     /// Each value should always be sorted.
     pub as_set_routes: BTreeMap<String, AsSetRoute>,

--- a/route_policy_cmp/src/bgp/trie.rs
+++ b/route_policy_cmp/src/bgp/trie.rs
@@ -1,12 +1,77 @@
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::{iter::*, net::*};
 
-use ip_network_table_deps_treebitmap::IpLookupTable;
+use ip_network_table_deps_treebitmap::*;
+use ipnet::*;
+
+use crate::parse::address_prefix::{address_prefix_contains, RangeOperator};
 
 // TODO: Efficient implementations for `Hash` and `Clone`.
 #[derive(Default)]
 pub struct IpTrie {
     pub v4: IpLookupTable<Ipv4Addr, ()>,
     pub v6: IpLookupTable<Ipv6Addr, ()>,
+}
+
+const EXPECT_IP_NET: &str =
+    "Arguments to `IpNet` should be valid because they are from another `IpNet` in `IpTrie`.";
+
+impl IpTrie {
+    pub fn new() -> Self {
+        Self {
+            v4: IpLookupTable::new(),
+            v6: IpLookupTable::new(),
+        }
+    }
+
+    pub fn matches(&self, ip: &IpNet) -> Vec<IpNet> {
+        match ip {
+            IpNet::V4(ip) => self
+                .v4
+                .matches(ip.addr())
+                .map(|(ip, masklen, _)| {
+                    IpNet::V4(Ipv4Net::new(ip, masklen as u8).expect(EXPECT_IP_NET))
+                })
+                .collect(),
+            IpNet::V6(ip) => self
+                .v6
+                .matches(ip.addr())
+                .map(|(ip, masklen, _)| {
+                    IpNet::V6(Ipv6Net::new(ip, masklen as u8).expect(EXPECT_IP_NET))
+                })
+                .collect(),
+        }
+    }
+
+    pub fn match_ip_range(&self, ip: &IpNet, range_operator: RangeOperator) -> bool {
+        for ours in self.matches(ip).iter().rev() {
+            if address_prefix_contains(ours, range_operator, ip) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+impl std::iter::Extend<IpNet> for IpTrie {
+    fn extend<T: IntoIterator<Item = IpNet>>(&mut self, iter: T) {
+        for ip in iter {
+            _ = match ip {
+                IpNet::V4(ip) => self.v4.insert(ip.addr(), ip.prefix_len() as u32, ()),
+                IpNet::V6(ip) => self.v6.insert(ip.addr(), ip.prefix_len() as u32, ()),
+            }
+        }
+    }
+}
+
+impl<'a> std::iter::Extend<&'a IpNet> for IpTrie {
+    fn extend<T: IntoIterator<Item = &'a IpNet>>(&mut self, iter: T) {
+        for ip in iter {
+            _ = match ip {
+                IpNet::V4(ip) => self.v4.insert(ip.addr(), ip.prefix_len() as u32, ()),
+                IpNet::V6(ip) => self.v6.insert(ip.addr(), ip.prefix_len() as u32, ()),
+            }
+        }
+    }
 }
 
 impl Eq for IpTrie {}
@@ -68,5 +133,41 @@ impl Clone for IpTrie {
             .iter()
             .for_each(|(ip, masklen, _)| _ = v6.insert(ip, masklen, ()));
         Self { v4, v6 }
+    }
+}
+
+pub struct IpTrieIter<'a> {
+    v4: Iter<'a, Ipv4Addr, ()>,
+    v6: Iter<'a, Ipv6Addr, ()>,
+}
+
+impl<'a> Iterator for IpTrieIter<'a> {
+    type Item = IpNet;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((ip, masklen, _)) = self.v4.next() {
+            return Some(IpNet::V4(
+                Ipv4Net::new(ip, masklen as u8).expect(EXPECT_IP_NET),
+            ));
+        }
+        if let Some((ip, masklen, _)) = self.v6.next() {
+            return Some(IpNet::V6(
+                Ipv6Net::new(ip, masklen as u8).expect(EXPECT_IP_NET),
+            ));
+        }
+        None
+    }
+}
+
+impl<'a> IntoIterator for &'a IpTrie {
+    type Item = IpNet;
+
+    type IntoIter = IpTrieIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter {
+            v4: self.v4.iter(),
+            v6: self.v6.iter(),
+        }
     }
 }

--- a/route_policy_cmp/src/bgp/trie.rs
+++ b/route_policy_cmp/src/bgp/trie.rs
@@ -1,0 +1,72 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use ip_network_table_deps_treebitmap::IpLookupTable;
+
+// TODO: Efficient implementations for `Hash` and `Clone`.
+#[derive(Default)]
+pub struct IpTrie {
+    pub v4: IpLookupTable<Ipv4Addr, ()>,
+    pub v6: IpLookupTable<Ipv6Addr, ()>,
+}
+
+impl Eq for IpTrie {}
+
+impl PartialEq for IpTrie {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(self.cmp(other), std::cmp::Ordering::Equal)
+    }
+}
+
+impl PartialOrd for IpTrie {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for IpTrie {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        for (ours, theirs) in self.v4.iter().zip(other.v4.iter()) {
+            match ours.cmp(&theirs) {
+                std::cmp::Ordering::Equal => (),
+                non_equal => return non_equal,
+            }
+        }
+        for (ours, theirs) in self.v6.iter().zip(other.v6.iter()) {
+            match ours.cmp(&theirs) {
+                std::cmp::Ordering::Equal => (),
+                non_equal => return non_equal,
+            }
+        }
+        std::cmp::Ordering::Equal
+    }
+}
+
+impl std::hash::Hash for IpTrie {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.v4.iter().collect::<Vec<_>>().hash(state);
+        self.v6.iter().collect::<Vec<_>>().hash(state);
+    }
+}
+
+impl std::fmt::Debug for IpTrie {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IpTrie")
+            .field("v4", &self.v4.iter().collect::<Vec<_>>())
+            .field("v4", &self.v4.iter().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl Clone for IpTrie {
+    fn clone(&self) -> Self {
+        let mut v4 = IpLookupTable::with_capacity(self.v4.len());
+        self.v4
+            .iter()
+            .for_each(|(ip, masklen, _)| _ = v4.insert(ip, masklen, ()));
+        let mut v6 = IpLookupTable::with_capacity(self.v6.len());
+        self.v6
+            .iter()
+            .for_each(|(ip, masklen, _)| _ = v6.insert(ip, masklen, ()));
+        Self { v4, v6 }
+    }
+}


### PR DESCRIPTION
Use `ip_network_table-deps-treebitmap::IpLookupTable` with `IpLookupTable::matches` for `AsSetRoute.routes`, instead of sorted `Vec<IpNet>` with `core::slice::binary_search` and bidirectional linear search.

The intention is to simplify the codebase and improve correctness.

However, early test results are not optimistic:

- I have to create wrappers around `ip_network_table-deps-treebitmap::IpLookupTable` because it doesn't implement `(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)`. The codebase is thus more complicated.
- Simple benchmarks to generate `0x10000` reports yield the exact same performance as using `Vec` with `binary_search`. That is, both the time taken and the numbers of `Bad` reports are the same.
  - Experiments with 0, 1, or 2 `flatten_as_set_routes`, respectively, all yield the same performance.

The above results suggests that this change brings no improvement, @cunha.