### PR TITLE
Pseudo customer AS set check when AS exports w/ itself as `filter`

### DIFF
--- a/route_verification/bgp/Cargo.toml
+++ b/route_verification/bgp/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 dashmap = "5.5"
-hashbrown = "0.14"
+hashbrown = { version = "0.14", features = ["rayon"] }
 ipnet = { version = "2.8", features = ["serde"] }
 lazy-regex = "3.0"
 rayon = "1.7"

--- a/route_verification/bgp/src/cmp.rs
+++ b/route_verification/bgp/src/cmp.rs
@@ -10,7 +10,12 @@ use {
     SkipReason::*,
 };
 
+mod compliance;
+mod filter;
 mod hill;
+mod peering;
+
+pub use {compliance::*, filter::*, peering::*};
 
 pub const RECURSION_LIMIT: isize = 0x100;
 
@@ -139,7 +144,15 @@ impl Compare {
                 }
             });
         }
-        let mut report = match self.check_compliant(dump, &from_an.exports, to) {
+        let mut report = match (Compliance {
+            cmp: self,
+            dump,
+            accept_num: to,
+            self_num: from,
+            export: true,
+        })
+        .check(&from_an.exports)
+        {
             None => {
                 return self.verbosity.show_success.then_some(match to {
                     Some(to) => OkExport { from, to },
@@ -179,7 +192,15 @@ impl Compare {
                 items: vec![Skip(ImportEmpty)],
             });
         }
-        let mut report = match self.check_compliant(dump, &to_an.imports, Some(from)) {
+        let mut report = match (Compliance {
+            cmp: self,
+            dump,
+            accept_num: Some(from),
+            self_num: to,
+            export: false,
+        })
+        .check(&to_an.imports)
+        {
             None => return self.verbosity.show_success.then_some(OkImport { from, to }),
             Some(report) => report,
         };
@@ -195,114 +216,6 @@ impl Compare {
                 .then_some(MehImport { from, to, items }),
             BadF(items) => Some(BadImport { from, to, items }),
         }
-    }
-
-    pub fn check_compliant(
-        &self,
-        dump: &QueryDump,
-        policy: &Versions,
-        accept_num: Option<u64>,
-    ) -> AnyReport {
-        Some(
-            match self.prefix {
-                IpNet::V4(_) => self.check_casts(dump, &policy.ipv4, accept_num),
-                IpNet::V6(_) => self.check_casts(dump, &policy.ipv6, accept_num),
-            }? | self.check_casts(dump, &policy.any, accept_num)?,
-        )
-    }
-
-    pub fn check_casts(
-        &self,
-        dump: &QueryDump,
-        casts: &Casts,
-        accept_num: Option<u64>,
-    ) -> AnyReport {
-        let mut report = SkipFBad::const_default();
-        let specific_cast = match is_multicast(&self.prefix) {
-            true => &casts.multicast,
-            false => &casts.unicast,
-        };
-        for entry in [specific_cast, &casts.any].into_iter().flatten() {
-            report |= self.check_entry(dump, entry, accept_num).to_any()?;
-        }
-        Some(report)
-    }
-
-    pub fn check_entry(
-        &self,
-        dump: &QueryDump,
-        entry: &Entry,
-        accept_num: Option<u64>,
-    ) -> AllReport {
-        let peering_report = match accept_num {
-            Some(accept_num) => self
-                .check_peering_actions(dump, &entry.mp_peerings, accept_num)
-                .to_all()
-                .map_err(|mut report| {
-                    if self.verbosity.per_entry_err {
-                        report.push(NoMatch(Peering));
-                    }
-                    report
-                })?,
-            None => OkT,
-        };
-        let filter_report = CheckFilter {
-            dump,
-            compare: self,
-            verbosity: self.verbosity,
-        }
-        .check(&entry.mp_filter, self.recursion_limit)
-        .to_all()
-        .map_err(|mut report| {
-            if self.verbosity.per_entry_err {
-                report.push(NoMatch(Filter));
-            }
-            report
-        })?;
-        Ok(peering_report & filter_report)
-    }
-
-    pub fn check_peering_actions<'a, I>(
-        &self,
-        dump: &QueryDump,
-        peerings: I,
-        accept_num: u64,
-    ) -> AnyReport
-    where
-        I: IntoIterator<Item = &'a PeeringAction>,
-    {
-        let mut report = SkipFBad::const_default();
-        for peering_actions in peerings.into_iter() {
-            let new = self.check_peering_action(dump, peering_actions, accept_num);
-            report |= new.to_any()?;
-        }
-        Some(report)
-    }
-
-    pub fn check_peering_action(
-        &self,
-        dump: &QueryDump,
-        peering_actions: &PeeringAction,
-        accept_num: u64,
-    ) -> AllReport {
-        CheckPeering {
-            dump,
-            compare: self,
-            accept_num,
-            verbosity: self.verbosity,
-        }
-        .check(&peering_actions.mp_peering, self.recursion_limit)
-        // Skipped.
-        /* ?
-        .join(self.check_actions(&peering_actions.actions)?)
-        .to_all()
-        */
-    }
-
-    /// We skip community checks, but this could be an enhancement.
-    /// <https://github.com/SichangHe/parse_rpsl_policy/issues/16>.
-    pub fn check_actions(&self, _actions: &Actions) -> AllReport {
-        Ok(OkT)
     }
 
     pub fn goes_through_num(&self, num: u64) -> bool {

--- a/route_verification/bgp/src/cmp.rs
+++ b/route_verification/bgp/src/cmp.rs
@@ -7,7 +7,7 @@ use super::*;
 
 use {
     AsPathEntry::*, MatchProblem::*, OkTBad::*, Report::*, ReportItem::*, SkipFBad::*,
-    SkipReason::*,
+    SkipReason::*, SpecialCase::*,
 };
 
 mod compliance;

--- a/route_verification/bgp/src/cmp/compliance.rs
+++ b/route_verification/bgp/src/cmp/compliance.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+pub struct Compliance<'a> {
+    pub cmp: &'a Compare,
+    pub dump: &'a QueryDump,
+    pub accept_num: Option<u64>,
+    pub self_num: u64,
+    pub export: bool,
+}
+impl<'a> Compliance<'a> {
+    pub fn check(&self, policy: &Versions) -> AnyReport {
+        Some(
+            match self.cmp.prefix {
+                IpNet::V4(_) => self.check_casts(&policy.ipv4),
+                IpNet::V6(_) => self.check_casts(&policy.ipv6),
+            }? | self.check_casts(&policy.any)?,
+        )
+    }
+
+    pub fn check_casts(&self, casts: &Casts) -> AnyReport {
+        let mut report = SkipFBad::const_default();
+        let specific_cast = match is_multicast(&self.cmp.prefix) {
+            true => &casts.multicast,
+            false => &casts.unicast,
+        };
+        for entry in [specific_cast, &casts.any].into_iter().flatten() {
+            report |= self.check_entry(entry).to_any()?;
+        }
+        Some(report)
+    }
+
+    pub fn check_entry(&self, entry: &Entry) -> AllReport {
+        let peering_report = match self.accept_num {
+            Some(accept_num) => CheckPeering {
+                c: self,
+                accept_num,
+            }
+            .check_peering_actions(&entry.mp_peerings)
+            .to_all()
+            .map_err(|mut report| {
+                if self.cmp.verbosity.per_entry_err {
+                    report.push(NoMatch(Peering));
+                }
+                report
+            })?,
+            None => OkT,
+        };
+        let filter_report = self
+            .check_filter(&entry.mp_filter, self.cmp.recursion_limit)
+            .to_all()
+            .map_err(|mut report| {
+                if self.cmp.verbosity.per_entry_err {
+                    report.push(NoMatch(Filter));
+                }
+                report
+            })?;
+        Ok(peering_report & filter_report)
+    }
+}
+
+impl<'a> VerbosityReport for Compliance<'a> {
+    fn get_verbosity(&self) -> Verbosity {
+        self.cmp.verbosity
+    }
+}

--- a/route_verification/bgp/src/cmp/filter.rs
+++ b/route_verification/bgp/src/cmp/filter.rs
@@ -3,16 +3,8 @@ use parse::{Filter::*, *};
 
 use super::*;
 
-use SkipFBad::*;
-
-pub struct CheckFilter<'a> {
-    pub dump: &'a QueryDump,
-    pub compare: &'a Compare,
-    pub verbosity: Verbosity,
-}
-
-impl<'a> CheckFilter<'a> {
-    pub fn check(&self, filter: &'a Filter, depth: isize) -> AnyReport {
+impl<'a> Compliance<'a> {
+    pub fn check_filter(&self, filter: &'a Filter, depth: isize) -> AnyReport {
         if depth <= 0 {
             return recursion_any_report(RecurSrc::CheckFilter);
         }
@@ -32,7 +24,7 @@ impl<'a> CheckFilter<'a> {
             And { left, right } => self.filter_and(left, right, depth).to_any(),
             Or { left, right } => self.filter_or(left, right, depth),
             Not(filter) => self.filter_not(filter, depth),
-            Group(filter) => self.check(filter, depth),
+            Group(filter) => self.check_filter(filter, depth),
             Community(community) => self.filter_community(community),
             Invalid(reason) => self.invalid_filter(reason),
         }
@@ -45,7 +37,7 @@ impl<'a> CheckFilter<'a> {
         };
         let mut report = SkipFBad::const_default();
         for filter in &filter_set.filters {
-            report |= self.check(filter, depth - 1)?;
+            report |= self.check_filter(filter, depth - 1)?;
         }
         Some(report)
     }
@@ -54,17 +46,17 @@ impl<'a> CheckFilter<'a> {
         let routes = match self.dump.as_routes.get(&num) {
             Some(r) => r,
             None => {
-                return match self.compare.goes_through_num(num) {
+                return match self.cmp.goes_through_num(num) {
                     true => self.skip_any_report(|| SkipReason::AsRoutesUnrecorded(num)),
                     false => empty_skip_any_report(),
                 }
             }
         };
-        if match_ips(&self.compare.prefix, routes, op) {
-            None
-        } else {
-            self.no_match_any_report(|| MatchProblem::FilterAsNum(num, op))
+        if match_ips(&self.cmp.prefix, routes, op) {
+            return None;
         }
+        // TODO: Check exporting customers.
+        self.no_match_any_report(|| MatchProblem::FilterAsNum(num, op))
     }
 
     fn filter_prefixes<I>(&self, prefixes: I) -> AnyReport
@@ -73,7 +65,7 @@ impl<'a> CheckFilter<'a> {
     {
         if prefixes
             .into_iter()
-            .all(|prefix| !prefix.contains(&self.compare.prefix))
+            .all(|prefix| !prefix.contains(&self.cmp.prefix))
         {
             self.no_match_any_report(|| MatchProblem::FilterPrefixes)
         } else {
@@ -142,7 +134,7 @@ impl<'a> CheckFilter<'a> {
             None => return self.skip_any_report(|| SkipReason::AsSetRouteUnrecorded(name.into())),
         };
 
-        if match_ips(&self.compare.prefix, &as_set_route.routes, op) {
+        if match_ips(&self.cmp.prefix, &as_set_route.routes, op) {
             return None;
         }
 
@@ -188,21 +180,22 @@ impl<'a> CheckFilter<'a> {
         if depth <= 0 {
             return recursion_all_report(RecurSrc::FilterAnd);
         }
-        Ok(self.check(left, depth - 1).to_all()? & self.check(right, depth).to_all()?)
+        Ok(self.check_filter(left, depth - 1).to_all()?
+            & self.check_filter(right, depth).to_all()?)
     }
 
     fn filter_or(&self, left: &'a Filter, right: &'a Filter, depth: isize) -> AnyReport {
         if depth <= 0 {
             return recursion_any_report(RecurSrc::FilterOr);
         }
-        Some(self.check(left, depth - 1)? | self.check(right, depth)?)
+        Some(self.check_filter(left, depth - 1)? | self.check_filter(right, depth)?)
     }
 
     fn filter_not(&self, filter: &'a Filter, depth: isize) -> AnyReport {
         if depth <= 0 {
             return recursion_any_report(RecurSrc::FilterNot);
         }
-        match self.check(filter, depth) {
+        match self.check_filter(filter, depth) {
             Some(report @ SkipF(_)) | Some(report @ MehF(_)) => {
                 Some(report | self.no_match_any_report(|| MatchProblem::Filter)?)
             }
@@ -219,11 +212,5 @@ impl<'a> CheckFilter<'a> {
 
     fn invalid_filter(&self, reason: &str) -> AnyReport {
         self.bad_rpsl_any_report(|| RpslError::InvalidFilter(reason.into()))
-    }
-}
-
-impl<'a> VerbosityReport for CheckFilter<'a> {
-    fn get_verbosity(&self) -> Verbosity {
-        self.verbosity
     }
 }

--- a/route_verification/bgp/src/lib.rs
+++ b/route_verification/bgp/src/lib.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use as_rel::{AsRelDb, Relationship::*};
 use bloom::BloomHashSet;
 use ipnet::IpNet;
+use parse::*;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 

--- a/route_verification/bgp/src/lib.rs
+++ b/route_verification/bgp/src/lib.rs
@@ -9,8 +9,6 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 pub mod cmp;
-pub mod filter;
-pub mod peering;
 pub mod query;
 pub mod report;
 pub mod stats;
@@ -29,8 +27,6 @@ pub use {
     wrapper::{parse_mrt, Line},
 };
 
-use filter::CheckFilter;
 use map::*;
-use peering::CheckPeering;
 use report::*;
 use verbosity::*;

--- a/route_verification/bgp/src/lib.rs
+++ b/route_verification/bgp/src/lib.rs
@@ -20,7 +20,7 @@ pub mod wrapper;
 pub use {
     cmp::Compare,
     map::{self, AsPathEntry},
-    query::{AsSetRoute, QueryDump},
+    query::{customer_set, AsSetRoute, QueryDump},
     report::{MatchProblem, Report, ReportItem, SkipReason},
     stats::{AsPairStats, AsStats, UpDownHillStats},
     verbosity::Verbosity,

--- a/route_verification/bgp/src/query.rs
+++ b/route_verification/bgp/src/query.rs
@@ -103,7 +103,7 @@ impl QueryDump {
 
     /// Same as [`from_dump`](#method.from_dump),
     /// but with customer pseudo sets injected under names `c#{aut_num}`.
-    pub fn from_dump_and_as_relations(mut dump: Dump, db: &AsRelDb) -> Self {
+    pub fn from_dump_and_as_relationship(mut dump: Dump, db: &AsRelDb) -> Self {
         let pseudo_sets = make_customer_pseudo_set(db);
         dump.as_sets.extend(pseudo_sets);
         Self::from_dump(dump)

--- a/route_verification/bgp/src/query.rs
+++ b/route_verification/bgp/src/query.rs
@@ -1,7 +1,10 @@
 use hashbrown::HashMap;
-use parse::*;
 
 use super::*;
+
+mod pseudo_set;
+
+pub use pseudo_set::*;
 
 /// Routes for one AS set, including the unrecorded and sets.
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -96,6 +99,14 @@ impl QueryDump {
             as_routes,
             as_set_routes,
         }
+    }
+
+    /// Same as [`from_dump`](#method.from_dump),
+    /// but with customer pseudo sets injected under names `c#{aut_num}`.
+    pub fn from_dump_and_as_relations(mut dump: Dump, db: &AsRelDb) -> Self {
+        let pseudo_sets = make_customer_pseudo_set(db);
+        dump.as_sets.extend(pseudo_sets);
+        Self::from_dump(dump)
     }
 }
 

--- a/route_verification/bgp/src/query/pseudo_set.rs
+++ b/route_verification/bgp/src/query/pseudo_set.rs
@@ -23,9 +23,9 @@ pub fn make_customer_pseudo_set(db: &AsRelDb) -> BTreeMap<String, AsSet> {
             large
         })
         .into_par_iter()
-        .map(|(an, customers)| {
+        .map(|(aut_num, customers)| {
             (
-                format!("c#{an}"),
+                customer_set(aut_num),
                 AsSet {
                     body: "".into(),
                     members: customers,
@@ -34,4 +34,9 @@ pub fn make_customer_pseudo_set(db: &AsRelDb) -> BTreeMap<String, AsSet> {
             )
         })
         .collect()
+}
+
+/// Name of the customer pseudo set corresponding to `aut_num`.
+pub fn customer_set(aut_num: u64) -> String {
+    format!("c#{aut_num}")
 }

--- a/route_verification/bgp/src/query/pseudo_set.rs
+++ b/route_verification/bgp/src/query/pseudo_set.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+/// Extract customers for each AutNum into a set under the name `c#{aut_num}`.
+pub fn make_customer_pseudo_set(db: &AsRelDb) -> BTreeMap<String, AsSet> {
+    db.source2dest
+        .par_iter()
+        .fold(
+            BTreeMap::<_, Vec<_>>::new,
+            |mut result, ((from, to), relationship)| {
+                match *relationship {
+                    P2C => result.entry(*from).or_default().push(*to),
+                    P2P => (),
+                    C2P => result.entry(*to).or_default().push(*from),
+                }
+                result
+            },
+        )
+        .reduce(BTreeMap::new, |a, b| {
+            let (mut large, small) = if a.len() > b.len() { (a, b) } else { (b, a) };
+            for (key, value) in small {
+                large.entry(key).or_default().extend(value);
+            }
+            large
+        })
+        .into_par_iter()
+        .map(|(an, customers)| {
+            (
+                format!("c#{an}"),
+                AsSet {
+                    body: "".into(),
+                    members: customers,
+                    set_members: vec![],
+                },
+            )
+        })
+        .collect()
+}

--- a/route_verification/bgp/src/report.rs
+++ b/route_verification/bgp/src/report.rs
@@ -113,6 +113,7 @@ pub enum SkipReason {
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum SpecialCase {
     Uphill,
+    ExportCustomers,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]

--- a/route_verification/bgp/src/report/any.rs
+++ b/route_verification/bgp/src/report/any.rs
@@ -94,7 +94,7 @@ impl SkipFBad {
                 }
                 MehF(i) | BadF(i) => {
                     items.extend(i);
-                    SkipF(items)
+                    MehF(items)
                 }
             },
             BadF(mut items) => match other {

--- a/route_verification/bgp/src/tests.rs
+++ b/route_verification/bgp/src/tests.rs
@@ -3,5 +3,5 @@ use std::collections::HashMap;
 use super::*;
 
 pub mod cmp;
-mod query;
 mod psedo_set;
+mod query;

--- a/route_verification/bgp/src/tests.rs
+++ b/route_verification/bgp/src/tests.rs
@@ -4,3 +4,4 @@ use super::*;
 
 pub mod cmp;
 mod query;
+mod psedo_set;

--- a/route_verification/bgp/src/tests.rs
+++ b/route_verification/bgp/src/tests.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+
 use super::*;
 
-mod cmp;
+pub mod cmp;
+mod query;

--- a/route_verification/bgp/src/tests/cmp.rs
+++ b/route_verification/bgp/src/tests/cmp.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use dashmap::DashMap;
 use maplit::hashmap;
 use parse::*;
@@ -96,12 +94,13 @@ fn expected_ok_skip_checks() -> [Vec<Report>; 1] {
 const DB_FILE: &str = "1239|3130|-1
 1239|2914|0
 2914|9583|-1
+2914|4096|-1
 ";
 
 #[test]
 fn stats() -> Result<()> {
     let query = query()?;
-    let db = AsRelDb::from_lines(DB_FILE.lines())?;
+    let db = as_relationship_db()?;
     for (expected, line) in expected_stats().into_iter().zip(LINES) {
         let map = DashMap::new();
         let mut compare = Compare::with_line_dump(line)?;
@@ -118,7 +117,14 @@ fn expected_stats() -> [HashMap<u64, AsStats>; 1] {
     ]
 }
 
-fn query() -> Result<QueryDump> {
-    let dump: Dump = serde_json::from_str(DUMP)?;
-    Ok(QueryDump::from_dump(dump))
+pub fn dump() -> Result<Dump> {
+    Ok(serde_json::from_str(DUMP)?)
+}
+
+pub fn query() -> Result<QueryDump> {
+    Ok(QueryDump::from_dump(dump()?))
+}
+
+pub fn as_relationship_db() -> Result<AsRelDb> {
+    AsRelDb::from_lines(DB_FILE.lines())
 }

--- a/route_verification/bgp/src/tests/psedo_set.rs
+++ b/route_verification/bgp/src/tests/psedo_set.rs
@@ -1,0 +1,54 @@
+use super::*;
+
+use {AsPathEntry::Seq, Report::*, ReportItem::*, SkipReason::*, SpecialCase::*};
+
+const DUMP: &str = r#"{"aut_nums":{"45891":{"body":"","imports":{"any":{"any":[{"mp_peerings":[{"mp_peering":{"remote_as":{"Single":{"Set":"AS45891:AS-CUSTOMERS"}}}}],"mp_filter":"Any"}]}},"exports":{"any":{"any":[{"mp_peerings":[{"mp_peering":{"remote_as":{"Single":{"Num":139609}}}}],"mp_filter":{"AsNum":[45891,"NoOp"]}},{"mp_peerings":[{"mp_peering":{"remote_as":{"Single":{"Num":60725}}}}],"mp_filter":{"AsNum":[45891,"NoOp"]}}]}}}},"as_sets":{},"route_sets":{},"peering_sets":{},"filter_sets":{},"as_routes":{"134525":["103.2.88.0/24"],"45891":[]}}"#;
+
+const DB_FILE: &str = "139609|45891|-1
+45891|134525|-1
+";
+
+#[test]
+fn export_customers() -> Result<()> {
+    let query = query()?;
+    let verbosity = Verbosity {
+        check_customer: true,
+        ..Verbosity::minimum_all()
+    };
+    let cmp = Compare {
+        prefix: "103.2.88.0/24".parse()?,
+        as_path: vec![Seq(139609), Seq(45891)],
+        recursion_limit: 1,
+        verbosity,
+    };
+    let actual = cmp.check(&query);
+    assert_eq!(actual, expected_reports_with_customers());
+    Ok(())
+}
+
+fn expected_reports_with_customers() -> Vec<Report> {
+    vec![
+        MehExport {
+            from: 45891,
+            to: 139609,
+            items: vec![Special(ExportCustomers)],
+        },
+        SkipImport {
+            from: 45891,
+            to: 139609,
+            items: vec![Skip(AutNumUnrecorded(139609))],
+        },
+    ]
+}
+
+fn dump() -> Result<Dump> {
+    Ok(serde_json::from_str(DUMP)?)
+}
+
+fn db() -> Result<AsRelDb> {
+    AsRelDb::from_lines(DB_FILE.lines())
+}
+
+fn query() -> Result<QueryDump> {
+    Ok(QueryDump::from_dump_and_as_relations(dump()?, &db()?))
+}

--- a/route_verification/bgp/src/tests/psedo_set.rs
+++ b/route_verification/bgp/src/tests/psedo_set.rs
@@ -50,5 +50,5 @@ fn db() -> Result<AsRelDb> {
 }
 
 fn query() -> Result<QueryDump> {
-    Ok(QueryDump::from_dump_and_as_relations(dump()?, &db()?))
+    Ok(QueryDump::from_dump_and_as_relationship(dump()?, &db()?))
 }

--- a/route_verification/bgp/src/tests/query.rs
+++ b/route_verification/bgp/src/tests/query.rs
@@ -6,7 +6,8 @@ use super::{cmp::*, *};
 fn psedo_customer_set() -> Result<()> {
     let dump = dump()?;
     let db = as_relationship_db()?;
-    let mut actual = HashMap::from_iter(QueryDump::from_dump_and_as_relations(dump, &db).as_sets);
+    let mut actual =
+        HashMap::from_iter(QueryDump::from_dump_and_as_relationship(dump, &db).as_sets);
     actual.iter_mut().for_each(|(_, v)| v.members.sort());
     assert_eq!(actual, expected_as_sets());
     Ok(())

--- a/route_verification/bgp/src/tests/query.rs
+++ b/route_verification/bgp/src/tests/query.rs
@@ -6,7 +6,8 @@ use super::{cmp::*, *};
 fn psedo_customer_set() -> Result<()> {
     let dump = dump()?;
     let db = as_relationship_db()?;
-    let actual = HashMap::from_iter(QueryDump::from_dump_and_as_relations(dump, &db).as_sets);
+    let mut actual = HashMap::from_iter(QueryDump::from_dump_and_as_relations(dump, &db).as_sets);
+    actual.iter_mut().for_each(|(_, v)| v.members.sort());
     assert_eq!(actual, expected_as_sets());
     Ok(())
 }

--- a/route_verification/bgp/src/tests/query.rs
+++ b/route_verification/bgp/src/tests/query.rs
@@ -1,0 +1,16 @@
+use maplit::hashmap;
+
+use super::{cmp::*, *};
+
+#[test]
+fn psedo_customer_set() -> Result<()> {
+    let dump = dump()?;
+    let db = as_relationship_db()?;
+    let actual = HashMap::from_iter(QueryDump::from_dump_and_as_relations(dump, &db).as_sets);
+    assert_eq!(actual, expected_as_sets());
+    Ok(())
+}
+
+fn expected_as_sets() -> HashMap<String, AsSet> {
+    hashmap! {"c#2914".into()=> AsSet { body: "".into(), members: vec![4096, 9583], set_members: vec![] }, "c#1239".into()=> AsSet { body: "".into(), members: vec![3130], set_members: vec![] }}
+}

--- a/route_verification/bgp/src/verbosity.rs
+++ b/route_verification/bgp/src/verbosity.rs
@@ -117,7 +117,7 @@ pub trait VerbosityReport {
     where
         F: Fn() -> SpecialCase,
     {
-        if self.get_verbosity().show_skips {
+        if self.get_verbosity().show_meh {
             special_any_report(reason())
         } else {
             empty_meh_any_report()

--- a/route_verification/bgp/src/verbosity.rs
+++ b/route_verification/bgp/src/verbosity.rs
@@ -20,6 +20,8 @@ pub struct Verbosity {
     pub all_err: bool,
     /// Record [`AsPathPairWithSet`], [`SetSingleExport`].
     pub record_set: bool,
+    /// Check for pseudo customer sets.
+    pub check_customer: bool,
 }
 
 impl std::fmt::Debug for Verbosity {
@@ -33,6 +35,7 @@ impl std::fmt::Debug for Verbosity {
             per_entry_err,
             all_err,
             record_set,
+            check_customer,
         } = self;
         for (is_true, tag) in [
             (stop_at_first, "stop_at_first"),
@@ -42,6 +45,7 @@ impl std::fmt::Debug for Verbosity {
             (per_entry_err, "per_entry_err"),
             (all_err, "all_err"),
             (record_set, "record_set"),
+            (check_customer, "check_customer"),
         ] {
             if *is_true {
                 result.entry(&tag);
@@ -72,6 +76,7 @@ impl Verbosity {
             per_entry_err: false,
             all_err: false,
             record_set: false,
+            check_customer: false,
         }
     }
 }

--- a/route_verification/src/evcxr_examples.rs
+++ b/route_verification/src/evcxr_examples.rs
@@ -70,7 +70,7 @@ fn parse_bgp_lines() -> Result<()> {
 
     let db = AsRelDb::load_bz("data/20230701.as-rel.bz2")?;
     let parsed = Dump::pal_read("parsed_all")?;
-    let query: QueryDump = QueryDump::from_dump_and_as_relations(parsed, &db);
+    let query: QueryDump = QueryDump::from_dump_and_as_relationship(parsed, &db);
     println!("{:#?}", query.aut_nums.iter().next());
     let mut bgp_lines: Vec<Line> = parse_mrt("data/mrts/rib.20230619.2200.bz2")?;
 

--- a/route_verification/src/evcxr_examples.rs
+++ b/route_verification/src/evcxr_examples.rs
@@ -68,11 +68,11 @@ fn parse_bgp_lines() -> Result<()> {
     env::set_var("POLARS_FMT_MAX_COLS", "32");
     env::set_var("POLARS_TABLE_WIDTH", "160");
 
+    let db = AsRelDb::load_bz("data/20230701.as-rel.bz2")?;
     let parsed = Dump::pal_read("parsed_all")?;
-    let query: QueryDump = QueryDump::from_dump(parsed);
+    let query: QueryDump = QueryDump::from_dump_and_as_relations(parsed, &db);
     println!("{:#?}", query.aut_nums.iter().next());
     let mut bgp_lines: Vec<Line> = parse_mrt("data/mrts/rib.20230619.2200.bz2")?;
-    let db = AsRelDb::load_bz("data/20230701.as-rel.bz2")?;
 
     Ok(())
 }


### PR DESCRIPTION
https://github.com/SichangHe/internet_route_verification/issues/26#issuecomment-1655295512

- `QueryDump::from_dump_and_as_relationship` to consider AS relationships are pseudo AS sets named `c#{aut_num}`.
- "Meh" has its own `Report` cases.
- Separate out `Compliance` from `Compare` and rid `CheckFilter`.
- `Verbosity::check_customer`.