### PR TITLE
Accept `AS-ANY` for `<peering>`

### DIFF
--- a/route_verification/bgp/src/cmp/peering.rs
+++ b/route_verification/bgp/src/cmp/peering.rs
@@ -68,6 +68,7 @@ impl<'a> CheckPeering<'a> {
             return recursion_any_report(RecurSrc::RemoteAsName(as_name.clone()));
         }
         match as_name {
+            AsName::Any => None,
             AsName::Num(num) => self.check_remote_as_num(*num),
             AsName::Set(name) => {
                 self.check_remote_as_set(name, depth, &mut BloomHashSet::with_capacity(2048, 32768))

--- a/route_verification/parse/src/aut_sys.rs
+++ b/route_verification/parse/src/aut_sys.rs
@@ -5,6 +5,7 @@ use super::*;
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum AsName {
+    Any,
     Num(u64),
     Set(String),
     Invalid(String),
@@ -13,12 +14,14 @@ pub enum AsName {
 /// A simple AS field is either a AS number or a AS set.
 /// Otherwise, return `AsExpr::Invalid`.
 pub fn parse_as_name(field: String) -> Result<AsName> {
-    if is_as_set(&field) {
-        // AS set.
-        return Ok(AsName::Set(field));
-    }
-    let num = parse_aut_num_name(&field).context("parsing as name")?;
-    Ok(AsName::Num(num)) // AS number.
+    Ok(if is_any(&field) {
+        AsName::Any
+    } else if is_as_set(&field) {
+        AsName::Set(field) // AS set.
+    } else {
+        let num = parse_aut_num_name(&field).context("parsing as name")?;
+        AsName::Num(num) // AS number.
+    })
 }
 
 pub fn is_as_set(field: &str) -> bool {

--- a/route_verification/parse/src/filter.rs
+++ b/route_verification/parse/src/filter.rs
@@ -34,7 +34,7 @@ pub fn parse_filter(mp_filter: lex::Filter, mp_peerings: &[PeeringAction]) -> Fi
 }
 
 pub fn parse_path_attribute(attr: String, mp_peerings: &[PeeringAction]) -> Filter {
-    if regex_is_match!(r"^(as-)?any$"i, &attr) {
+    if is_any(&attr) {
         Filter::Any
     } else if regex_is_match!(r"^peeras$"i, &attr) {
         peer_as_filter(mp_peerings)
@@ -51,6 +51,10 @@ pub fn parse_path_attribute(attr: String, mp_peerings: &[PeeringAction]) -> Filt
     } else {
         Filter::AsPathRE(attr)
     }
+}
+
+pub fn is_any(attr: &str) -> bool {
+    regex_is_match!(r"^(as-)?any$"i, attr)
 }
 
 pub fn is_filter_set(attr: &str) -> bool {

--- a/route_verification/parse/src/filter.rs
+++ b/route_verification/parse/src/filter.rs
@@ -61,6 +61,7 @@ pub fn is_filter_set(attr: &str) -> bool {
     regex_is_match!(r"^(AS\d+:)?fltr-\S+$"i, attr)
 }
 
+/// Process a `PeerAS` filter.
 /// PeerAS can be used instead of the AS number of the peer AS.
 /// <https://www.rfc-editor.org/rfc/rfc2622#page-19>.
 pub fn peer_as_filter(mp_peerings: &[PeeringAction]) -> Filter {
@@ -77,6 +78,7 @@ pub fn peer_as_filter(mp_peerings: &[PeeringAction]) -> Filter {
                 actions: _,
             }),
         ) => match as_name {
+            AsName::Any => Filter::Any,
             AsName::Num(num) => Filter::AsNum(*num, NoOp),
             AsName::Set(name) => Filter::AsSet(name.into(), NoOp),
             AsName::Invalid(reason) => {

--- a/route_verification/parse/src/lex.rs
+++ b/route_verification/parse/src/lex.rs
@@ -76,13 +76,10 @@ pub fn parse_lexed_as_set(lexed: lex::AsOrRouteSet) -> Result<(String, AsSet)> {
     let mut members = Vec::with_capacity(max_length);
     let mut set_members = Vec::with_capacity(max_length);
     for member in lexed.members {
-        let member = match parse_as_name(member) {
-            Ok(m) => m,
-            Err(err) => {
-                return Err(err.context(format!("parsing AS Set {}\n{}", lexed.name, lexed.body)))
-            }
-        };
+        let member = parse_as_name(member)
+            .with_context(|| format!("parsing AS Set {}\n{}", lexed.name, lexed.body))?;
         match member {
+            AsName::Any => bail!("AS Set {} contains `ANY`", lexed.name),
             AsName::Num(n) => members.push(n),
             AsName::Set(set) => set_members.push(set),
             AsName::Invalid(reason) => {

--- a/route_verification/parse/src/lib.rs
+++ b/route_verification/parse/src/lib.rs
@@ -27,7 +27,7 @@ pub use {
     aut_num::AutNum,
     aut_sys::{is_as_set, parse_as_name, AsName},
     dump::Dump,
-    filter::{is_filter_set, parse_filter, Filter},
+    filter::{is_any, is_filter_set, parse_filter, Filter},
     mp_import::{parse_imports, Casts, Entry, Versions},
     peering::{
         is_peering_set, parse_mp_peering, parse_mp_peerings, AsExpr, Peering, PeeringAction,

--- a/route_verification/parse/src/tests/lex.rs
+++ b/route_verification/parse/src/tests/lex.rs
@@ -7,7 +7,7 @@ use crate::{
     set::{AsSet, FilterSet, PeeringSet, RouteSet, RouteSetMember::*},
     AsExpr::*,
     AsName::*,
-    Filter::*,
+    Filter::{Any, *},
     RangeOperator::NoOp,
     RouterExpr::*,
 };


### PR DESCRIPTION
Apply the same rules for `ANY` `<filter>`s to `<peering>`.

- Introduce `AsName::Any`.
- AS Sets cannot contain any kind of `ANY`.

    <details>
    <summary>AS Sets that already break this rule.</summary>

    ```sh
    [2023-07-31T09:38:34Z ERROR route_verification_parse::lex] AS Set AS25192:AS-IX contains `ANY`
    [2023-07-31T09:38:34Z ERROR route_verification_parse::lex] AS Set AS200070:AS-IX contains `ANY`
    [2023-07-31T09:38:34Z ERROR route_verification_parse::lex] AS Set AS1887:AS-Peerings:AS8501 contains `ANY`
    ```

    </details>
