### PR TITLE
Summarize Lexer & Parser stats

### DIFF
--- a/route_verification/irr/src/lib.rs
+++ b/route_verification/irr/src/lib.rs
@@ -16,11 +16,13 @@ use parse::{
 use rayon::prelude::*;
 
 pub mod mbrs;
+pub mod stats;
 #[cfg(test)]
 mod tests;
 pub mod worker;
 
 use mbrs::*;
+use stats::Counts;
 use worker::{spawn_aut_num_worker, spawn_filter_set_worker, spawn_peering_set_worker};
 
 /// Gather `members` and `mp-members` expressions.

--- a/route_verification/irr/src/lib.rs
+++ b/route_verification/irr/src/lib.rs
@@ -62,7 +62,7 @@ pub fn parse_object(obj: RPSLObject, pd: &mut PreDump) -> Result<()> {
     match obj.class.as_str() {
         "aut-num" => pd.send_aut_num.send(obj)?,
         "as-set" => parse_as_set(obj, &mut pd.as_sets),
-        "route" | "route6" => parse_route(obj, &mut pd.as_routes, &mut pd.pseudo_route_sets),
+        "route" | "route6" => parse_route(obj, pd),
         "route-set" => parse_route_set(obj, &mut pd.route_sets),
         "filter-set" => pd.send_filter_set.send(obj)?,
         "peering-set" => pd.send_peering_set.send(obj)?,
@@ -80,25 +80,22 @@ fn parse_as_set(obj: RPSLObject, as_sets: &mut Vec<AsOrRouteSet>) {
     }
 }
 
-fn parse_route(
-    obj: RPSLObject,
-    as_routes: &mut BTreeMap<String, Vec<String>>,
-    pseudo_route_sets: &mut Map2DStringVec,
-) {
-    gather_ref(&obj, pseudo_route_sets);
+fn parse_route(obj: RPSLObject, pd: &mut PreDump) {
+    gather_ref(&obj, &mut pd.pseudo_route_sets);
     for RpslExpr {
         key,
         expr, /*AS*/
     } in expressions(lines_continued(obj.body.lines()))
     {
         if key == "origin" {
-            as_routes
+            pd.as_routes
                 .entry(expr.to_uppercase())
                 .or_default()
                 .push(obj.name /*The route*/);
             return;
         }
     }
+    pd.counts.unknown_err += 1;
     error!("Route object {} does not have an `origin` field.", obj.name);
 }
 
@@ -131,14 +128,18 @@ where
         send_peering_set,
         send_filter_set,
         as_routes,
+        counts: Default::default(),
     };
 
     for obj in rpsl_objects(io_wrapper_lines(db)) {
         if obj.body.len() > ONE_MEBIBYTE {
             // <https://github.com/SichangHe/parse_rpsl_policy/issues/6#issuecomment-1566121009>
+            pd.counts.skip += 1;
             warn!(
-                "Skipping {} object `{}` with body larger than 1MiB.",
-                obj.class, obj.name
+                "Skipping {} object `{}` with a {}MiB body.",
+                obj.class,
+                obj.name,
+                obj.body.len() / ONE_MEBIBYTE
             );
             continue;
         }
@@ -148,13 +149,17 @@ where
     pd.route_sets.extend(conclude_set(pd.pseudo_route_sets));
 
     drop((pd.send_aut_num, pd.send_peering_set, pd.send_filter_set));
-    let (aut_nums, pseudo_as_sets) = aut_num_worker.join().unwrap()?;
-    pd.as_sets.extend(pseudo_as_sets);
+    let an_out = aut_num_worker.join().unwrap()?;
+    pd.as_sets.extend(an_out.pseudo_as_sets);
     let peering_sets = peering_set_worker.join().unwrap()?;
     let filter_sets = filter_set_worker.join().unwrap()?;
 
+    // TODO: Return this.
+    let counts = pd.counts + an_out.counts;
+    debug!("read_db counts: {counts}.");
+
     Ok(Dump {
-        aut_nums,
+        aut_nums: an_out.aut_nums,
         as_sets: pd.as_sets,
         route_sets: pd.route_sets,
         peering_sets,
@@ -171,6 +176,7 @@ pub struct PreDump {
     pub send_peering_set: Sender<RPSLObject>,
     pub send_filter_set: Sender<RPSLObject>,
     pub as_routes: BTreeMap<String, Vec<String>>,
+    pub counts: Counts,
 }
 
 /// When some DBs have the same keys, any value could be used.

--- a/route_verification/irr/src/stats.rs
+++ b/route_verification/irr/src/stats.rs
@@ -1,0 +1,19 @@
+#[derive(Copy, Clone, Default)]
+pub struct Counts {
+    pub skip: usize,
+    pub parse_err: usize,
+    pub unknown_err: usize,
+}
+
+impl std::fmt::Display for Counts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            skip,
+            parse_err,
+            unknown_err,
+        } = self;
+        f.write_fmt(format_args!(
+            "{skip} skips, {parse_err} parsing errors, {unknown_err} unknown errors"
+        ))
+    }
+}

--- a/route_verification/irr/src/stats.rs
+++ b/route_verification/irr/src/stats.rs
@@ -5,6 +5,18 @@ pub struct Counts {
     pub unknown_err: usize,
 }
 
+impl std::ops::Add for Counts {
+    type Output = Counts;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            skip: self.skip + rhs.skip,
+            parse_err: self.parse_err + rhs.parse_err,
+            unknown_err: self.unknown_err + rhs.unknown_err,
+        }
+    }
+}
+
 impl std::fmt::Display for Counts {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {

--- a/route_verification/irr/src/worker.rs
+++ b/route_verification/irr/src/worker.rs
@@ -30,9 +30,7 @@ fn aut_num_worker(recv: Receiver<RPSLObject>) -> Result<(Vec<AutNum>, Vec<AsOrRo
 
     let mut aut_nums = Vec::new();
     let mut pseduo_as_sets = BTreeMap::new();
-    let mut n_skip = 0;
-    let mut n_parse_err = 0;
-    let mut n_unknown_err = 0;
+    let mut counts = Counts::default();
     while let Ok(obj) = recv.recv() {
         obj.write_to(&mut aut_num_child.stdin)?;
         gather_ref(&obj, &mut pseduo_as_sets);
@@ -47,15 +45,15 @@ fn aut_num_worker(recv: Receiver<RPSLObject>) -> Result<(Vec<AutNum>, Vec<AsOrRo
                     debug!("aut_num_child: {}", content.trim());
                 }
                 (Some(&"ParseException"), Some(_)) => {
-                    n_parse_err += 1;
+                    counts.parse_err += 1;
                     error!("aut_num_child: {}", line.trim());
                 }
                 (Some(&"Skip"), Some(content)) => {
-                    n_skip += 1;
+                    counts.skip += 1;
                     warn!("aut_num_child: {}", content.trim());
                 }
                 _ => {
-                    n_unknown_err += 1;
+                    counts.unknown_err += 1;
                     error!("aut_num_child: unknown: {}", line.trim());
                 }
             }
@@ -68,7 +66,7 @@ fn aut_num_worker(recv: Receiver<RPSLObject>) -> Result<(Vec<AutNum>, Vec<AsOrRo
         }
     }
     // TODO: Return these.
-    debug!("aut_num_child: {n_skip} skips, {n_parse_err} parsing errors, {n_unknown_err} unknown errors.");
+    debug!("aut_num_child counts: {counts}.");
     warn!("aut_num_worker exiting normally.");
     Ok((aut_nums, conclude_set(pseduo_as_sets)))
 }

--- a/route_verification/irr/src/worker.rs
+++ b/route_verification/irr/src/worker.rs
@@ -43,8 +43,8 @@ fn aut_num_worker(recv: Receiver<RPSLObject>) -> Result<AutNumWorkerOutput> {
                     debug!("aut_num_child: {}", content.trim());
                 }
                 (Some(&"ParseException"), Some(_)) => {
-                    counts.parse_err += 1;
-                    error!("aut_num_child: {}", line.trim());
+                    counts.lex_err += 1;
+                    warn!("aut_num_child: {}", line.trim());
                 }
                 (Some(&"Skip"), Some(content)) => {
                     counts.skip += 1;

--- a/route_verification/irr/src/worker.rs
+++ b/route_verification/irr/src/worker.rs
@@ -63,7 +63,7 @@ fn aut_num_worker(recv: Receiver<RPSLObject>) -> Result<AutNumWorkerOutput> {
             _ => (),
         }
     }
-    warn!("aut_num_worker exiting normally.");
+    debug!("aut_num_worker exiting normally.");
     Ok(AutNumWorkerOutput {
         aut_nums,
         pseudo_as_sets: conclude_set(pseduo_as_sets),
@@ -105,7 +105,7 @@ fn peering_set_worker(recv: Receiver<RPSLObject>) -> Result<Vec<PeeringSet>> {
             _ => (),
         }
     }
-    warn!("peering_set_worker exiting normally.");
+    debug!("peering_set_worker exiting normally.");
     Ok(peering_sets)
 }
 
@@ -137,6 +137,6 @@ fn filter_set_worker(recv: Receiver<RPSLObject>) -> Result<Vec<FilterSet>> {
             _ => (),
         }
     }
-    warn!("filter_set_worker exiting normally.");
+    debug!("filter_set_worker exiting normally.");
     Ok(filter_sets)
 }

--- a/route_verification/lex/src/lib.rs
+++ b/route_verification/lex/src/lib.rs
@@ -11,6 +11,7 @@ pub mod lines;
 pub mod mp_import;
 pub mod peering;
 pub mod rpsl_object;
+pub mod stats;
 #[cfg(any(test, feature = "test_util"))]
 pub mod test_util;
 #[cfg(test)]
@@ -25,4 +26,5 @@ pub use {
     mp_import::Versions,
     peering::{AsExpr, ComplexAsExpr, Peering},
     rpsl_object::{AsOrRouteSet, AutNum, FilterSet, PeeringSet},
+    stats::Counts,
 };

--- a/route_verification/lex/src/stats.rs
+++ b/route_verification/lex/src/stats.rs
@@ -1,6 +1,7 @@
 #[derive(Copy, Clone, Default)]
 pub struct Counts {
     pub skip: usize,
+    pub lex_err: usize,
     pub parse_err: usize,
     pub unknown_err: usize,
 }
@@ -11,6 +12,7 @@ impl std::ops::Add for Counts {
     fn add(self, rhs: Self) -> Self::Output {
         Self {
             skip: self.skip + rhs.skip,
+            lex_err: self.lex_err + rhs.lex_err,
             parse_err: self.parse_err + rhs.parse_err,
             unknown_err: self.unknown_err + rhs.unknown_err,
         }
@@ -21,11 +23,12 @@ impl std::fmt::Display for Counts {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
             skip,
+            lex_err,
             parse_err,
             unknown_err,
         } = self;
         f.write_fmt(format_args!(
-            "{skip} skips, {parse_err} parsing errors, {unknown_err} unknown errors"
+            "{skip} skips, {lex_err} lexing errors, {parse_err} parsing errors, {unknown_err} unknown errors"
         ))
     }
 }

--- a/route_verification/parse/src/dump.rs
+++ b/route_verification/parse/src/dump.rs
@@ -136,8 +136,10 @@ impl Dump {
             .collect::<Result<Vec<_>, _>>()?;
         Ok(merge_dumps(dumps))
     }
+}
 
-    pub fn log_count(&self) {
+impl std::fmt::Display for Dump {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
             aut_nums,
             as_sets,
@@ -146,15 +148,15 @@ impl Dump {
             filter_sets,
             as_routes,
         } = self;
-        debug!(
-            "Parsed {} aut_nums, {} as_sets, {} route_sets, {} peering_sets, {} filter_sets, {} as_routes.",
+        f.write_fmt(format_args!(
+            "{} aut_nums, {} as_sets, {} route_sets, {} peering_sets, {} filter_sets, {} as_routes",
             aut_nums.len(),
             as_sets.len(),
             route_sets.len(),
             peering_sets.len(),
             filter_sets.len(),
             as_routes.len(),
-        )
+        ))
     }
 }
 
@@ -181,6 +183,9 @@ where
 }
 
 /// Merge `dumps` into a single [`Dump`] in parallel, with no ordering guarantee.
-pub fn merge_dumps(dumps: Vec<Dump>) -> Dump {
+pub fn merge_dumps<I>(dumps: I) -> Dump
+where
+    I: IntoParallelIterator<Item = Dump>,
+{
     dumps.into_par_iter().reduce(Dump::default, Dump::merge)
 }

--- a/route_verification/parse/src/lex.rs
+++ b/route_verification/parse/src/lex.rs
@@ -33,29 +33,20 @@ pub fn parse_lexed(lexed: lex::Dump) -> (Dump, Counts) {
 }
 
 pub fn parse_lexed_aut_nums(lexed: Vec<lex::AutNum>) -> (BTreeMap<u64, AutNum>, Counts) {
-    lexed
-        .into_par_iter()
-        .fold(
-            || (BTreeMap::new(), Counts::default()),
-            |(mut acc, mut counts), lexed| match parse_lexed_aut_num(lexed, &mut counts) {
-                Ok((num, aut_num)) => {
-                    acc.insert(num, aut_num);
-                    (acc, counts)
-                }
-                Err(e) => {
-                    counts.parse_err += 1;
-                    error!("{e:?}");
-                    (acc, counts)
-                }
-            },
-        )
-        .reduce(
-            || (BTreeMap::new(), Counts::default()),
-            |(mut map0, counts0), (map1, counts1)| {
-                map0.extend(map1);
-                (map0, counts0 + counts1)
-            },
-        )
+    par_process_map_counts(
+        lexed,
+        |(mut acc, mut counts), lexed| match parse_lexed_aut_num(lexed, &mut counts) {
+            Ok((num, aut_num)) => {
+                acc.insert(num, aut_num);
+                (acc, counts)
+            }
+            Err(e) => {
+                counts.parse_err += 1;
+                error!("{e:?}");
+                (acc, counts)
+            }
+        },
+    )
 }
 
 pub fn parse_lexed_aut_num(aut_num: lex::AutNum, counts: &mut Counts) -> Result<(u64, AutNum)> {
@@ -88,29 +79,20 @@ pub fn parse_aut_num_name(name: &str) -> Result<u64> {
 }
 
 pub fn parse_lexed_as_sets(lexed: Vec<lex::AsOrRouteSet>) -> (BTreeMap<String, AsSet>, Counts) {
-    lexed
-        .into_par_iter()
-        .fold(
-            || (BTreeMap::new(), Counts::default()),
-            |(mut acc, mut counts), lexed| match parse_lexed_as_set(lexed) {
-                Ok((name, as_set)) => {
-                    acc.insert(name, as_set);
-                    (acc, counts)
-                }
-                Err(e) => {
-                    counts.parse_err += 1;
-                    error!("{e:?}");
-                    (acc, counts)
-                }
-            },
-        )
-        .reduce(
-            || (BTreeMap::new(), Counts::default()),
-            |(mut map0, counts0), (map1, counts1)| {
-                map0.extend(map1);
-                (map0, counts0 + counts1)
-            },
-        )
+    par_process_map_counts(
+        lexed,
+        |(mut acc, mut counts), lexed| match parse_lexed_as_set(lexed) {
+            Ok((name, as_set)) => {
+                acc.insert(name, as_set);
+                (acc, counts)
+            }
+            Err(e) => {
+                counts.parse_err += 1;
+                error!("{e:?}");
+                (acc, counts)
+            }
+        },
+    )
 }
 
 pub fn parse_lexed_as_set(lexed: lex::AsOrRouteSet) -> Result<(String, AsSet)> {
@@ -139,29 +121,20 @@ pub fn parse_lexed_as_set(lexed: lex::AsOrRouteSet) -> Result<(String, AsSet)> {
 pub fn parse_lexed_route_sets(
     lexed: Vec<lex::AsOrRouteSet>,
 ) -> (BTreeMap<String, RouteSet>, Counts) {
-    lexed
-        .into_par_iter()
-        .fold(
-            || (BTreeMap::new(), Counts::default()),
-            |(mut acc, mut counts), lexed| match parse_lexed_route_set(lexed) {
-                Ok((name, route_set)) => {
-                    acc.insert(name, route_set);
-                    (acc, counts)
-                }
-                Err(e) => {
-                    counts.parse_err += 1;
-                    error!("{e:?}");
-                    (acc, counts)
-                }
-            },
-        )
-        .reduce(
-            || (BTreeMap::new(), Counts::default()),
-            |(mut map0, counts0), (map1, counts1)| {
-                map0.extend(map1);
-                (map0, counts0 + counts1)
-            },
-        )
+    par_process_map_counts(
+        lexed,
+        |(mut acc, mut counts), lexed| match parse_lexed_route_set(lexed) {
+            Ok((name, route_set)) => {
+                acc.insert(name, route_set);
+                (acc, counts)
+            }
+            Err(e) => {
+                counts.parse_err += 1;
+                error!("{e:?}");
+                (acc, counts)
+            }
+        },
+    )
 }
 
 pub fn parse_lexed_route_set(lexed: lex::AsOrRouteSet) -> Result<(String, RouteSet)> {
@@ -189,29 +162,20 @@ pub fn parse_lexed_route_set(lexed: lex::AsOrRouteSet) -> Result<(String, RouteS
 pub fn parse_lexed_peering_sets(
     lexed: Vec<lex::PeeringSet>,
 ) -> (BTreeMap<String, PeeringSet>, Counts) {
-    lexed
-        .into_par_iter()
-        .fold(
-            || (BTreeMap::new(), Counts::default()),
-            |(mut acc, mut counts), lexed| match parse_lexed_peering_set(lexed) {
-                Ok((name, peering_set)) => {
-                    acc.insert(name, peering_set);
-                    (acc, counts)
-                }
-                Err(e) => {
-                    counts.parse_err += 1;
-                    error!("{e:?}");
-                    (acc, counts)
-                }
-            },
-        )
-        .reduce(
-            || (BTreeMap::new(), Counts::default()),
-            |(mut map0, counts0), (map1, counts1)| {
-                map0.extend(map1);
-                (map0, counts0 + counts1)
-            },
-        )
+    par_process_map_counts(
+        lexed,
+        |(mut acc, mut counts), lexed| match parse_lexed_peering_set(lexed) {
+            Ok((name, peering_set)) => {
+                acc.insert(name, peering_set);
+                (acc, counts)
+            }
+            Err(e) => {
+                counts.parse_err += 1;
+                error!("{e:?}");
+                (acc, counts)
+            }
+        },
+    )
 }
 
 pub fn parse_lexed_peering_set(lexed: lex::PeeringSet) -> Result<(String, PeeringSet)> {
@@ -233,29 +197,20 @@ pub fn parse_lexed_peering_set(lexed: lex::PeeringSet) -> Result<(String, Peerin
 pub fn parse_lexed_filter_sets(
     lexed: Vec<lex::FilterSet>,
 ) -> (BTreeMap<String, FilterSet>, Counts) {
-    lexed
-        .into_par_iter()
-        .fold(
-            || (BTreeMap::new(), Counts::default()),
-            |(mut acc, mut counts), lexed| match parse_lexed_filter_set(lexed, &mut counts) {
-                Ok((name, filter_set)) => {
-                    acc.insert(name, filter_set);
-                    (acc, counts)
-                }
-                Err(e) => {
-                    counts.parse_err += 1;
-                    error!("{e:?}");
-                    (acc, counts)
-                }
-            },
-        )
-        .reduce(
-            || (BTreeMap::new(), Counts::default()),
-            |(mut map0, counts0), (map1, counts1)| {
-                map0.extend(map1);
-                (map0, counts0 + counts1)
-            },
-        )
+    par_process_map_counts(
+        lexed,
+        |(mut acc, mut counts), lexed| match parse_lexed_filter_set(lexed, &mut counts) {
+            Ok((name, filter_set)) => {
+                acc.insert(name, filter_set);
+                (acc, counts)
+            }
+            Err(e) => {
+                counts.parse_err += 1;
+                error!("{e:?}");
+                (acc, counts)
+            }
+        },
+    )
 }
 
 pub fn parse_lexed_filter_set(
@@ -282,22 +237,32 @@ pub fn parse_lexed_filter_set(
 pub fn parse_lexed_as_routes(
     as_routes: BTreeMap<String, Vec<String>>,
 ) -> (BTreeMap<u64, Vec<IpNet>>, Counts) {
-    as_routes
+    par_process_map_counts(
+        as_routes,
+        |(mut acc, mut counts), lexed| match parse_lexed_as_route(&lexed) {
+            Ok((num, routes)) => {
+                acc.insert(num, routes);
+                (acc, counts)
+            }
+            Err(e) => {
+                counts.parse_err += 1;
+                error!("Parsing routes for {lexed:?}: {e}.");
+                (acc, counts)
+            }
+        },
+    )
+}
+
+pub fn par_process_map_counts<I, In, F, K, V>(input: I, transform: F) -> (BTreeMap<K, V>, Counts)
+where
+    I: IntoParallelIterator<Item = In>,
+    F: Fn((BTreeMap<K, V>, Counts), In) -> (BTreeMap<K, V>, Counts) + Send + Sync,
+    K: Ord + Send + Sync,
+    V: Send + Sync,
+{
+    input
         .into_par_iter()
-        .fold(
-            || (BTreeMap::new(), Counts::default()),
-            |(mut acc, mut counts), lexed| match parse_lexed_as_route(&lexed) {
-                Ok((num, routes)) => {
-                    acc.insert(num, routes);
-                    (acc, counts)
-                }
-                Err(e) => {
-                    counts.parse_err += 1;
-                    error!("Parsing routes for {lexed:?}: {e}.");
-                    (acc, counts)
-                }
-            },
-        )
+        .fold(|| (BTreeMap::new(), Counts::default()), transform)
         .reduce(
             || (BTreeMap::new(), Counts::default()),
             |(mut map0, counts0), (map1, counts1)| {

--- a/route_verification/parse/src/lex.rs
+++ b/route_verification/parse/src/lex.rs
@@ -1,9 +1,9 @@
-use ::lex;
+use ::lex::{self, Counts};
 use lazy_regex::regex_captures;
 
 use super::*;
 
-pub fn parse_lexed(lexed: lex::Dump) -> Dump {
+pub fn parse_lexed(lexed: lex::Dump) -> (Dump, Counts) {
     debug!("Start to parse lexed dump.");
     let lex::Dump {
         aut_nums,
@@ -13,26 +13,52 @@ pub fn parse_lexed(lexed: lex::Dump) -> Dump {
         filter_sets,
         as_routes,
     } = lexed;
+    let (aut_nums, an_counts) = parse_lexed_aut_nums(aut_nums);
+    let (as_sets, as_counts) = parse_lexed_as_sets(as_sets);
+    let (route_sets, rs_counts) = parse_lexed_route_sets(route_sets);
+    let (peering_sets, ps_counts) = parse_lexed_peering_sets(peering_sets);
+    let (filter_sets, fs_counts) = parse_lexed_filter_sets(filter_sets);
+    let (as_routes, ar_counts) = parse_lexed_as_routes(as_routes);
     let dump = Dump {
-        aut_nums: parse_lexed_aut_nums(aut_nums),
-        as_sets: parse_lexed_as_sets(as_sets),
-        route_sets: parse_lexed_route_sets(route_sets),
-        peering_sets: parse_lexed_peering_sets(peering_sets),
-        filter_sets: parse_lexed_filter_sets(filter_sets),
-        as_routes: parse_lexed_as_routes(as_routes),
+        aut_nums,
+        as_sets,
+        route_sets,
+        peering_sets,
+        filter_sets,
+        as_routes,
     };
-    dump.log_count();
-    dump
+    debug!("parse_lexed: Parsed {dump}.");
+    let counts = an_counts + as_counts + rs_counts + ps_counts + fs_counts + ar_counts;
+    (dump, counts)
 }
 
-pub fn parse_lexed_aut_nums(lexed: Vec<lex::AutNum>) -> BTreeMap<u64, AutNum> {
+pub fn parse_lexed_aut_nums(lexed: Vec<lex::AutNum>) -> (BTreeMap<u64, AutNum>, Counts) {
     lexed
         .into_par_iter()
-        .filter_map(|l| parse_lexed_aut_num(l).map_err(|e| error!("{e:?}")).ok())
-        .collect()
+        .fold(
+            || (BTreeMap::new(), Counts::default()),
+            |(mut acc, mut counts), lexed| match parse_lexed_aut_num(lexed, &mut counts) {
+                Ok((num, aut_num)) => {
+                    acc.insert(num, aut_num);
+                    (acc, counts)
+                }
+                Err(e) => {
+                    counts.parse_err += 1;
+                    error!("{e:?}");
+                    (acc, counts)
+                }
+            },
+        )
+        .reduce(
+            || (BTreeMap::new(), Counts::default()),
+            |(mut map0, counts0), (map1, counts1)| {
+                map0.extend(map1);
+                (map0, counts0 + counts1)
+            },
+        )
 }
 
-pub fn parse_lexed_aut_num(aut_num: lex::AutNum) -> Result<(u64, AutNum)> {
+pub fn parse_lexed_aut_num(aut_num: lex::AutNum, counts: &mut Counts) -> Result<(u64, AutNum)> {
     let num = parse_aut_num_name(&aut_num.name).context(format!("parsing {aut_num:?}"))?;
     let lex::AutNum {
         name: _,
@@ -40,8 +66,8 @@ pub fn parse_lexed_aut_num(aut_num: lex::AutNum) -> Result<(u64, AutNum)> {
         imports,
         exports,
     } = aut_num;
-    let imports = parse_imports(imports);
-    let exports = parse_imports(exports);
+    let imports = parse_imports(imports, counts);
+    let exports = parse_imports(exports, counts);
     Ok((
         num,
         AutNum {
@@ -61,11 +87,30 @@ pub fn parse_aut_num_name(name: &str) -> Result<u64> {
     }
 }
 
-pub fn parse_lexed_as_sets(lexed: Vec<lex::AsOrRouteSet>) -> BTreeMap<String, AsSet> {
+pub fn parse_lexed_as_sets(lexed: Vec<lex::AsOrRouteSet>) -> (BTreeMap<String, AsSet>, Counts) {
     lexed
         .into_par_iter()
-        .filter_map(|l| parse_lexed_as_set(l).map_err(|e| error!("{e:?}")).ok())
-        .collect()
+        .fold(
+            || (BTreeMap::new(), Counts::default()),
+            |(mut acc, mut counts), lexed| match parse_lexed_as_set(lexed) {
+                Ok((name, as_set)) => {
+                    acc.insert(name, as_set);
+                    (acc, counts)
+                }
+                Err(e) => {
+                    counts.parse_err += 1;
+                    error!("{e:?}");
+                    (acc, counts)
+                }
+            },
+        )
+        .reduce(
+            || (BTreeMap::new(), Counts::default()),
+            |(mut map0, counts0), (map1, counts1)| {
+                map0.extend(map1);
+                (map0, counts0 + counts1)
+            },
+        )
 }
 
 pub fn parse_lexed_as_set(lexed: lex::AsOrRouteSet) -> Result<(String, AsSet)> {
@@ -91,11 +136,32 @@ pub fn parse_lexed_as_set(lexed: lex::AsOrRouteSet) -> Result<(String, AsSet)> {
     Ok((lexed.name, as_set))
 }
 
-pub fn parse_lexed_route_sets(lexed: Vec<lex::AsOrRouteSet>) -> BTreeMap<String, RouteSet> {
+pub fn parse_lexed_route_sets(
+    lexed: Vec<lex::AsOrRouteSet>,
+) -> (BTreeMap<String, RouteSet>, Counts) {
     lexed
         .into_par_iter()
-        .filter_map(|l| parse_lexed_route_set(l).map_err(|e| error!("{e:?}")).ok())
-        .collect()
+        .fold(
+            || (BTreeMap::new(), Counts::default()),
+            |(mut acc, mut counts), lexed| match parse_lexed_route_set(lexed) {
+                Ok((name, route_set)) => {
+                    acc.insert(name, route_set);
+                    (acc, counts)
+                }
+                Err(e) => {
+                    counts.parse_err += 1;
+                    error!("{e:?}");
+                    (acc, counts)
+                }
+            },
+        )
+        .reduce(
+            || (BTreeMap::new(), Counts::default()),
+            |(mut map0, counts0), (map1, counts1)| {
+                map0.extend(map1);
+                (map0, counts0 + counts1)
+            },
+        )
 }
 
 pub fn parse_lexed_route_set(lexed: lex::AsOrRouteSet) -> Result<(String, RouteSet)> {
@@ -120,11 +186,32 @@ pub fn parse_lexed_route_set(lexed: lex::AsOrRouteSet) -> Result<(String, RouteS
     ))
 }
 
-pub fn parse_lexed_peering_sets(lexed: Vec<lex::PeeringSet>) -> BTreeMap<String, PeeringSet> {
+pub fn parse_lexed_peering_sets(
+    lexed: Vec<lex::PeeringSet>,
+) -> (BTreeMap<String, PeeringSet>, Counts) {
     lexed
         .into_par_iter()
-        .filter_map(|l| parse_lexed_peering_set(l).map_err(|e| error!("{e:?}")).ok())
-        .collect()
+        .fold(
+            || (BTreeMap::new(), Counts::default()),
+            |(mut acc, mut counts), lexed| match parse_lexed_peering_set(lexed) {
+                Ok((name, peering_set)) => {
+                    acc.insert(name, peering_set);
+                    (acc, counts)
+                }
+                Err(e) => {
+                    counts.parse_err += 1;
+                    error!("{e:?}");
+                    (acc, counts)
+                }
+            },
+        )
+        .reduce(
+            || (BTreeMap::new(), Counts::default()),
+            |(mut map0, counts0), (map1, counts1)| {
+                map0.extend(map1);
+                (map0, counts0 + counts1)
+            },
+        )
 }
 
 pub fn parse_lexed_peering_set(lexed: lex::PeeringSet) -> Result<(String, PeeringSet)> {
@@ -143,14 +230,38 @@ pub fn parse_lexed_peering_set(lexed: lex::PeeringSet) -> Result<(String, Peerin
     ))
 }
 
-pub fn parse_lexed_filter_sets(lexed: Vec<lex::FilterSet>) -> BTreeMap<String, FilterSet> {
+pub fn parse_lexed_filter_sets(
+    lexed: Vec<lex::FilterSet>,
+) -> (BTreeMap<String, FilterSet>, Counts) {
     lexed
         .into_par_iter()
-        .filter_map(|l| parse_lexed_filter_set(l).map_err(|e| error!("{e:?}")).ok())
-        .collect()
+        .fold(
+            || (BTreeMap::new(), Counts::default()),
+            |(mut acc, mut counts), lexed| match parse_lexed_filter_set(lexed, &mut counts) {
+                Ok((name, filter_set)) => {
+                    acc.insert(name, filter_set);
+                    (acc, counts)
+                }
+                Err(e) => {
+                    counts.parse_err += 1;
+                    error!("{e:?}");
+                    (acc, counts)
+                }
+            },
+        )
+        .reduce(
+            || (BTreeMap::new(), Counts::default()),
+            |(mut map0, counts0), (map1, counts1)| {
+                map0.extend(map1);
+                (map0, counts0 + counts1)
+            },
+        )
 }
 
-pub fn parse_lexed_filter_set(lexed: lex::FilterSet) -> Result<(String, FilterSet)> {
+pub fn parse_lexed_filter_set(
+    lexed: lex::FilterSet,
+    counts: &mut Counts,
+) -> Result<(String, FilterSet)> {
     if !is_filter_set(&lexed.name) {
         bail!(
             "{} is an invalid filter set name—parsing {lexed:?}",
@@ -162,7 +273,7 @@ pub fn parse_lexed_filter_set(lexed: lex::FilterSet) -> Result<(String, FilterSe
         filters: lexed
             .filters
             .into_iter()
-            .map(|f| parse_filter(f, &[]))
+            .map(|f| parse_filter(f, &[], counts))
             .collect(),
     };
     Ok((lexed.name, filter_set))
@@ -170,15 +281,30 @@ pub fn parse_lexed_filter_set(lexed: lex::FilterSet) -> Result<(String, FilterSe
 
 pub fn parse_lexed_as_routes(
     as_routes: BTreeMap<String, Vec<String>>,
-) -> BTreeMap<u64, Vec<IpNet>> {
+) -> (BTreeMap<u64, Vec<IpNet>>, Counts) {
     as_routes
-        .into_iter()
-        .filter_map(|as_route| {
-            parse_lexed_as_route(&as_route)
-                .map_err(|e| error!("Parsing routes for {as_route:?}: {e}."))
-                .ok()
-        })
-        .collect()
+        .into_par_iter()
+        .fold(
+            || (BTreeMap::new(), Counts::default()),
+            |(mut acc, mut counts), lexed| match parse_lexed_as_route(&lexed) {
+                Ok((num, routes)) => {
+                    acc.insert(num, routes);
+                    (acc, counts)
+                }
+                Err(e) => {
+                    counts.parse_err += 1;
+                    error!("Parsing routes for {lexed:?}: {e}.");
+                    (acc, counts)
+                }
+            },
+        )
+        .reduce(
+            || (BTreeMap::new(), Counts::default()),
+            |(mut map0, counts0), (map1, counts1)| {
+                map0.extend(map1);
+                (map0, counts0 + counts1)
+            },
+        )
 }
 
 pub fn parse_lexed_as_route((name, routes): &(String, Vec<String>)) -> Result<(u64, Vec<IpNet>)> {

--- a/route_verification/parse/src/mp_import.rs
+++ b/route_verification/parse/src/mp_import.rs
@@ -1,25 +1,25 @@
-use ::lex::mp_import;
+use ::lex::{mp_import, Counts};
 use itertools::chain;
 
 use super::*;
 
-pub fn parse_imports(imports: mp_import::Versions) -> Versions {
+pub fn parse_imports(imports: mp_import::Versions, counts: &mut Counts) -> Versions {
     let mp_import::Versions { any, ipv4, ipv6 } = imports;
-    let any = parse_casts(any);
-    let ipv4 = parse_casts(ipv4);
-    let ipv6 = parse_casts(ipv6);
+    let any = parse_casts(any, counts);
+    let ipv4 = parse_casts(ipv4, counts);
+    let ipv6 = parse_casts(ipv6, counts);
     Versions { any, ipv4, ipv6 }
 }
 
-pub fn parse_casts(casts: mp_import::Casts) -> Casts {
+pub fn parse_casts(casts: mp_import::Casts, counts: &mut Counts) -> Casts {
     let mp_import::Casts {
         any,
         unicast,
         multicast,
     } = casts;
-    let any = parse_entries(any);
-    let unicast = parse_entries(unicast);
-    let multicast = parse_entries(multicast);
+    let any = parse_entries(any, counts);
+    let unicast = parse_entries(unicast, counts);
+    let multicast = parse_entries(multicast, counts);
     Casts {
         any,
         unicast,
@@ -27,17 +27,20 @@ pub fn parse_casts(casts: mp_import::Casts) -> Casts {
     }
 }
 
-pub fn parse_entries(entries: Vec<mp_import::Entry>) -> Vec<Entry> {
-    entries.into_iter().map(parse_entry).collect()
+pub fn parse_entries(entries: Vec<mp_import::Entry>, counts: &mut Counts) -> Vec<Entry> {
+    entries
+        .into_iter()
+        .map(|e| parse_entry(e, counts))
+        .collect()
 }
 
-pub fn parse_entry(entry: mp_import::Entry) -> Entry {
+pub fn parse_entry(entry: mp_import::Entry, counts: &mut Counts) -> Entry {
     let mp_import::Entry {
         mp_peerings,
         mp_filter,
     } = entry;
     let mp_peerings = parse_mp_peerings(mp_peerings);
-    let mp_filter = parse_filter(mp_filter, &mp_peerings);
+    let mp_filter = parse_filter(mp_filter, &mp_peerings, counts);
     Entry {
         mp_peerings,
         mp_filter,

--- a/route_verification/parse/src/tests/lex.rs
+++ b/route_verification/parse/src/tests/lex.rs
@@ -1,4 +1,4 @@
-use ::lex::{action::Action::*, test_util::expected_dump};
+use ::lex::{action::Action::*, test_util::expected_dump, Counts};
 use maplit::btreemap;
 use net_literals::ip;
 
@@ -25,20 +25,32 @@ fn parse_name() {
 #[test]
 fn parse_dump() {
     let lexed = expected_dump();
-    let Dump {
-        aut_nums,
-        as_sets,
-        route_sets,
-        peering_sets,
-        filter_sets,
-        as_routes,
-    } = parse_lexed(lexed);
+    let (
+        Dump {
+            aut_nums,
+            as_sets,
+            route_sets,
+            peering_sets,
+            filter_sets,
+            as_routes,
+        },
+        Counts {
+            skip,
+            lex_err,
+            parse_err,
+            unknown_err,
+        },
+    ) = parse_lexed(lexed);
     assert_eq!(aut_nums, expected_aut_nums());
     assert_eq!(as_sets, expected_as_sets());
     assert_eq!(route_sets, expected_route_sets());
     assert_eq!(peering_sets, expected_peering_sets());
     assert_eq!(filter_sets, expected_filter_sets());
     assert_eq!(as_routes, expected_as_routes());
+    assert_eq!(skip, 0);
+    assert_eq!(lex_err, 0);
+    assert_eq!(parse_err, 0);
+    assert_eq!(unknown_err, 0);
 }
 
 fn expected_aut_nums() -> BTreeMap<u64, AutNum> {

--- a/route_verification/src/lib.rs
+++ b/route_verification/src/lib.rs
@@ -36,8 +36,8 @@ pub fn parse_all(args: Vec<String>) -> Result<()> {
     let output_dir = &args[3];
     debug!("Will dump to {output_dir}.");
 
-    let parsed = fs::parse_all(input_dir)?;
-    parsed.log_count();
+    let (parsed, counts) = fs::parse_all(input_dir)?;
+    println!("Summary\n\tParsed {parsed}.\n\t{counts}.");
 
     debug!("Starting to write the parsed dump.");
     parsed.pal_write(output_dir)?;

--- a/rpsl_lexer/dump.py
+++ b/rpsl_lexer/dump.py
@@ -28,8 +28,7 @@ def parse_mp_import(
         lexed = lex_with(mp_import, expr)
         import_export(lexed, imports, is_mp)
     except Exception as err:
-        tag = red("[parse_mp_import]")
-        print(f"{tag} {err} parsing `{expr}`.", file=sys.stderr)
+        print(f"{err} parsing `{expr}`.")
 
 
 def parse_aut_num(obj: RPSLObject):

--- a/rpsl_lexer/parse.py
+++ b/rpsl_lexer/parse.py
@@ -1,4 +1,3 @@
-from sys import stderr
 from typing import Iterable
 
 from pyparsing import ParseException, ParserElement
@@ -11,7 +10,7 @@ def lex_with(lexer: ParserElement, string: str) -> dict:
     try:
         return lexer.parse_string(string, parse_all=True).as_dict()
     except ParseException:
-        raise ValueError(f"ParseException parsing `{string}`")
+        raise ValueError(f"ParseException: Parsing `{string}`")
 
 
 def clean_action(
@@ -285,7 +284,7 @@ def apply_refine(left: dict[str, list | dict], right: dict) -> dict[str, dict | 
     # TODO: Deal with multiple <mp-peering>s.
     if len(right_peerings) > 1:
         raise ValueError(
-            f"Skipping REFINE expression with multiple <mp-peering>s: {right}."
+            f"Skip: Skipping REFINE expression with multiple <mp-peering>s: {right}."
         )
     right_peering_action = right_peerings[0]
     right_peering = right_peering_action["mp_peering"]
@@ -371,9 +370,9 @@ def import_export(lexed: dict, result: dict[str, dict[str, list]], is_mp: bool =
     """Parse lexed <mp-import> or <mp-export>."""
     if is_mp:
         if protocol_1 := lexed.get("protocol-1"):
-            print(f"Ignoring protocol-1: {protocol_1}.", file=stderr)
+            print(f"Ignore: Ignoring protocol-1: {protocol_1}.")
         if protocol_2 := lexed.get("protocol-2"):
-            print(f"Ignoring protocol-2: {protocol_2}.", file=stderr)
+            print(f"Ignore: Ignoring protocol-2: {protocol_2}.")
 
     afi_entries = set([("any", "any") if is_mp else ("ipv4", "unicast")])
     parsed_list = parse_afi_import_expression(lexed, afi_entries)


### PR DESCRIPTION
Pass `lex::stats::Count` everywhere in lexing and parsing to record number of

1. skips
2. lexing errors
3. parsing errors
4. unknown errors

Redirects Python AutNum lexer message to Rust via Stdout to record skips & lexing errors.

Current summary:

```
Summary
	Parsed 78951 aut_nums, 59724 as_sets, 24652 route_sets, 342 peering_sets, 202 filter_sets, 87534 as_routes.
	29 skips, 545 lexing errors, 376 parsing errors, 0 unknown errors.
```