### PR TITLE
Collapse `ReportItem` and recategorize reports

### DIFF
--- a/route_verification/bgp/src/cmp.rs
+++ b/route_verification/bgp/src/cmp.rs
@@ -178,6 +178,10 @@ impl Compare {
                 Some(to) => SkipExport { from, to, items },
                 None => SkipSingleExport { from, items },
             }),
+            UnrecAnyReport(items) => self.verbosity.show_unrec.then_some(match to {
+                Some(to) => UnrecExport { from, to, items },
+                None => UnrecSingleExport { from, items },
+            }),
             MehAnyReport(items) => self.verbosity.show_meh.then_some(match to {
                 Some(to) => MehExport { from, to, items },
                 None => MehSingleExport { from, items },
@@ -223,6 +227,11 @@ impl Compare {
                 self.verbosity
                     .show_skips
                     .then_some(SkipImport { from, to, items })
+            }
+            UnrecAnyReport(items) => {
+                self.verbosity
+                    .show_unrec
+                    .then_some(UnrecImport { from, to, items })
             }
             MehAnyReport(items) => self
                 .verbosity

--- a/route_verification/bgp/src/cmp.rs
+++ b/route_verification/bgp/src/cmp.rs
@@ -184,7 +184,7 @@ impl Compare {
             }),
             BadAnyReport(items) => Some(match to {
                 Some(to) => BadExport { from, to, items },
-                None => BadSingeExport { from, items },
+                None => BadSingleExport { from, items },
             }),
         }
     }

--- a/route_verification/bgp/src/cmp.rs
+++ b/route_verification/bgp/src/cmp.rs
@@ -96,9 +96,9 @@ impl Compare {
         match self.as_path.last()? {
             Seq(from) => match query.aut_nums.get(from) {
                 Some(from_an) => self.check_export(query, from_an, *from, None, &[]),
-                None => self.verbosity.show_skips.then(|| {
+                None => self.verbosity.show_unrec.then(|| {
                     let items = aut_num_unrecorded_items(*from);
-                    SkipSingleExport { from: *from, items }
+                    UnrecSingleExport { from: *from, items }
                 }),
             },
             Set(from) => self
@@ -118,9 +118,9 @@ impl Compare {
     ) -> Vec<Report> {
         let from_report = match query.aut_nums.get(&from) {
             Some(from_an) => self.check_export(query, from_an, from, Some(to), prev_path),
-            None => self.verbosity.show_skips.then(|| {
+            None => self.verbosity.show_unrec.then(|| {
                 let items = aut_num_unrecorded_items(from);
-                SkipExport { from, to, items }
+                UnrecExport { from, to, items }
             }),
         };
         let from_report = match (from_report, self.verbosity.stop_at_first) {
@@ -129,9 +129,9 @@ impl Compare {
         };
         let to_report = match query.aut_nums.get(&to) {
             Some(to_an) => self.check_import(query, to_an, from, to, prev_path),
-            None => self.verbosity.show_skips.then(|| {
+            None => self.verbosity.show_unrec.then(|| {
                 let items = aut_num_unrecorded_items(to);
-                SkipImport { from, to, items }
+                UnrecImport { from, to, items }
             }),
         };
         [from_report, to_report].into_iter().flatten().collect()

--- a/route_verification/bgp/src/cmp.rs
+++ b/route_verification/bgp/src/cmp.rs
@@ -6,10 +6,7 @@ use parse::*;
 
 use super::*;
 
-use {
-    as_regex::AsRegex, AsPathEntry::*, OkTBad::*, Report::*, ReportItem::*, SkipFBad::*,
-    SkipReason::*, SpecialCase::*,
-};
+use {as_regex::AsRegex, AsPathEntry::*, OkTBad::*, Report::*, ReportItem::*, SkipFBad::*};
 
 pub mod as_regex;
 mod compliance;
@@ -148,7 +145,7 @@ impl Compare {
     ) -> Option<Report> {
         if from_an.exports.is_default() {
             return self.verbosity.show_skips.then(|| {
-                let items = vec![Skip(ExportEmpty)];
+                let items = vec![SkipExportEmpty];
                 match to {
                     Some(to) => SkipExport { from, to, items },
                     None => SkipSingleExport { from, items },
@@ -202,7 +199,7 @@ impl Compare {
             return self.verbosity.show_skips.then(|| SkipImport {
                 from,
                 to,
-                items: vec![Skip(ImportEmpty)],
+                items: vec![SkipImportEmpty],
             });
         }
         let mut report = match (Compliance {
@@ -261,5 +258,5 @@ pub fn is_multicast(prefix: &IpNet) -> bool {
 }
 
 fn aut_num_unrecorded_items(aut_num: u64) -> Vec<ReportItem> {
-    vec![Skip(AutNumUnrecorded(aut_num))]
+    vec![SkipAutNumUnrecorded(aut_num)]
 }

--- a/route_verification/bgp/src/cmp.rs
+++ b/route_verification/bgp/src/cmp.rs
@@ -6,7 +6,9 @@ use parse::*;
 
 use super::*;
 
-use {as_regex::AsRegex, AsPathEntry::*, OkTBad::*, Report::*, ReportItem::*, SkipFBad::*};
+use {
+    as_regex::AsRegex, AllReportCase::*, AnyReportCase::*, AsPathEntry::*, Report::*, ReportItem::*,
+};
 
 pub mod as_regex;
 mod compliance;
@@ -172,15 +174,15 @@ impl Compare {
         };
         report.shrink_to_fit();
         match report {
-            SkipF(items) => self.verbosity.show_skips.then_some(match to {
+            SkipAnyReport(items) => self.verbosity.show_skips.then_some(match to {
                 Some(to) => SkipExport { from, to, items },
                 None => SkipSingleExport { from, items },
             }),
-            MehF(items) => self.verbosity.show_meh.then_some(match to {
+            MehAnyReport(items) => self.verbosity.show_meh.then_some(match to {
                 Some(to) => MehExport { from, to, items },
                 None => MehSingleExport { from, items },
             }),
-            BadF(items) => Some(match to {
+            BadAnyReport(items) => Some(match to {
                 Some(to) => BadExport { from, to, items },
                 None => BadSingeExport { from, items },
             }),
@@ -217,15 +219,16 @@ impl Compare {
         };
         report.shrink_to_fit();
         match report {
-            SkipF(items) => self
-                .verbosity
-                .show_skips
-                .then_some(SkipImport { from, to, items }),
-            MehF(items) => self
+            SkipAnyReport(items) => {
+                self.verbosity
+                    .show_skips
+                    .then_some(SkipImport { from, to, items })
+            }
+            MehAnyReport(items) => self
                 .verbosity
                 .show_meh
                 .then_some(MehImport { from, to, items }),
-            BadF(items) => Some(BadImport { from, to, items }),
+            BadAnyReport(items) => Some(BadImport { from, to, items }),
         }
     }
 

--- a/route_verification/bgp/src/cmp.rs
+++ b/route_verification/bgp/src/cmp.rs
@@ -258,5 +258,5 @@ pub fn is_multicast(prefix: &IpNet) -> bool {
 }
 
 fn aut_num_unrecorded_items(aut_num: u64) -> Vec<ReportItem> {
-    vec![SkipAutNumUnrecorded(aut_num)]
+    vec![UnrecordedAutNum(aut_num)]
 }

--- a/route_verification/bgp/src/cmp/as_regex.rs
+++ b/route_verification/bgp/src/cmp/as_regex.rs
@@ -43,7 +43,7 @@ impl<'a> AsRegex<'a> {
         match mem::take(&mut self.report) {
             BadF(_) => self
                 .c
-                .no_match_any_report(|| MatchRegexMismatch(self.expr.into())),
+                .bad_any_report(|| MatchRegexMismatch(self.expr.into())),
             non_bad => Some(non_bad),
         }
     }
@@ -77,6 +77,6 @@ impl<'a> AsRegex<'a> {
 
     fn invalid_err(&self) -> AnyReport {
         self.c
-            .bad_rpsl_any_report(|| RpslInvalidAsRegex(self.expr.into()))
+            .bad_any_report(|| RpslInvalidAsRegex(self.expr.into()))
     }
 }

--- a/route_verification/bgp/src/cmp/as_regex.rs
+++ b/route_verification/bgp/src/cmp/as_regex.rs
@@ -41,9 +41,7 @@ impl<'a> AsRegex<'a> {
             }
         }
         match mem::take(&mut self.report) {
-            BadF(_) => self
-                .c
-                .bad_any_report(|| MatchRegexMismatch(self.expr.into())),
+            BadF(_) => self.c.bad_any_report(|| MatchRegex(self.expr.into())),
             non_bad => Some(non_bad),
         }
     }

--- a/route_verification/bgp/src/cmp/as_regex.rs
+++ b/route_verification/bgp/src/cmp/as_regex.rs
@@ -8,7 +8,7 @@ pub struct AsRegex<'a> {
     pub c: &'a CheckFilter<'a>,
     pub interpreter: Interpreter,
     pub expr: &'a str,
-    pub report: SkipFBad,
+    pub report: AnyReportCase,
 }
 
 impl<'a> AsRegex<'a> {
@@ -41,7 +41,7 @@ impl<'a> AsRegex<'a> {
             }
         }
         match mem::take(&mut self.report) {
-            BadF(_) => self.c.bad_any_report(|| MatchRegex(self.expr.into())),
+            BadAnyReport(_) => self.c.bad_any_report(|| MatchRegex(self.expr.into())),
             non_bad => Some(non_bad),
         }
     }
@@ -61,7 +61,7 @@ impl<'a> AsRegex<'a> {
         }
         if let Some(filter) = filter {
             match self.c.check_filter(filter, depth) {
-                Some(skips @ SkipF(_)) => self.report |= skips,
+                Some(skips @ SkipAnyReport(_)) => self.report |= skips,
                 Some(_) => (),
                 None => result.push(self.interpreter.as_peering_char()),
             }

--- a/route_verification/bgp/src/cmp/as_regex.rs
+++ b/route_verification/bgp/src/cmp/as_regex.rs
@@ -18,7 +18,7 @@ impl<'a> AsRegex<'a> {
             Err(HasTilde) => {
                 return self
                     .c
-                    .skip_any_report(|| SkipReason::AsRegexWithTilde(self.expr.into()))
+                    .skip_any_report(|| SkipAsRegexWithTilde(self.expr.into()))
             }
             Err(_) => return self.invalid_err(),
         };
@@ -43,7 +43,7 @@ impl<'a> AsRegex<'a> {
         match mem::take(&mut self.report) {
             BadF(_) => self
                 .c
-                .no_match_any_report(|| MatchProblem::RegexMismatch(self.expr.into())),
+                .no_match_any_report(|| MatchRegexMismatch(self.expr.into())),
             non_bad => Some(non_bad),
         }
     }
@@ -77,6 +77,6 @@ impl<'a> AsRegex<'a> {
 
     fn invalid_err(&self) -> AnyReport {
         self.c
-            .bad_rpsl_any_report(|| RpslError::InvalidAsRegex(self.expr.into()))
+            .bad_rpsl_any_report(|| RpslInvalidAsRegex(self.expr.into()))
     }
 }

--- a/route_verification/bgp/src/cmp/compliance.rs
+++ b/route_verification/bgp/src/cmp/compliance.rs
@@ -41,7 +41,7 @@ impl<'a> Compliance<'a> {
             .to_all()
             .map_err(|mut report| {
                 if self.cmp.verbosity.per_entry_err {
-                    report.push(NoMatch(MatchProblem::Peering));
+                    report.push(MatchPeering);
                 }
                 report
             })?,
@@ -59,7 +59,7 @@ impl<'a> Compliance<'a> {
         .to_all()
         .map_err(|mut report| {
             if self.cmp.verbosity.per_entry_err {
-                report.push(NoMatch(MatchProblem::Filter));
+                report.push(MatchFilter);
             }
             report
         })?;

--- a/route_verification/bgp/src/cmp/compliance.rs
+++ b/route_verification/bgp/src/cmp/compliance.rs
@@ -20,7 +20,7 @@ impl<'a> Compliance<'a> {
     }
 
     pub fn check_casts(&self, casts: &Casts) -> AnyReport {
-        let mut report = SkipFBad::const_default();
+        let mut report = AnyReportCase::const_default();
         let specific_cast = match is_multicast(&self.cmp.prefix) {
             true => &casts.multicast,
             false => &casts.unicast,
@@ -45,7 +45,7 @@ impl<'a> Compliance<'a> {
                 }
                 report
             })?,
-            None => OkT,
+            None => OkAllReport,
         };
         let filter_report = CheckFilter {
             cmp: self.cmp,

--- a/route_verification/bgp/src/cmp/filter.rs
+++ b/route_verification/bgp/src/cmp/filter.rs
@@ -15,7 +15,7 @@ pub struct CheckFilter<'a> {
 impl<'a> CheckFilter<'a> {
     pub fn check_filter(&self, filter: &'a Filter, depth: isize) -> AnyReport {
         if depth <= 0 {
-            return recursion_any_report(RecurSrc::CheckFilter);
+            return recursion_any_report(RecCheckFilter);
         }
         match filter {
             FilterSet(name) => self.filter_set(name, depth),
@@ -30,7 +30,7 @@ impl<'a> CheckFilter<'a> {
             Not(filter) => self.filter_not(filter, depth),
             Group(filter) => self.check_filter(filter, depth),
             Community(community) => self.filter_community(community),
-            Unknown(unknown) => self.skip_any_report(|| UnknownFilter(unknown.into())),
+            Unknown(unknown) => self.skip_any_report(|| SkipUnknownFilter(unknown.into())),
             Invalid(reason) => self.invalid_filter(reason),
         }
     }
@@ -38,7 +38,7 @@ impl<'a> CheckFilter<'a> {
     fn filter_set(&self, name: &str, depth: isize) -> AnyReport {
         let filter_set = match self.query.filter_sets.get(name) {
             Some(f) => f,
-            None => return self.skip_any_report(|| SkipReason::FilterSetUnrecorded(name.into())),
+            None => return self.skip_any_report(|| SkipFilterSetUnrecorded(name.into())),
         };
         let mut report = SkipFBad::const_default();
         for filter in &filter_set.filters {
@@ -52,7 +52,7 @@ impl<'a> CheckFilter<'a> {
             Some(r) => r,
             None => {
                 return match self.cmp.goes_through_num(num) {
-                    true => self.skip_any_report(|| SkipReason::AsRoutesUnrecorded(num)),
+                    true => self.skip_any_report(|| SkipAsRoutesUnrecorded(num)),
                     false => empty_skip_any_report(),
                 }
             }
@@ -61,11 +61,11 @@ impl<'a> CheckFilter<'a> {
             return None;
         }
         if self.maybe_filter_customers(num, op) {
-            self.special_any_report(|| ExportCustomers)
+            self.special_any_report(|| SpecExportCustomers)
         } else if self.maybe_filter_as_is_origin(num, op) {
-            self.special_any_report(|| AsIsOriginButNoRoute(num))
+            self.special_any_report(|| SpecAsIsOriginButNoRoute(num))
         } else {
-            self.no_match_any_report(|| MatchProblem::FilterAsNum(num, op))
+            self.no_match_any_report(|| MatchFilterAsNum(num, op))
         }
     }
 
@@ -112,7 +112,7 @@ impl<'a> CheckFilter<'a> {
             .into_iter()
             .all(|prefix| !prefix.contains(&self.cmp.prefix))
         {
-            self.no_match_any_report(|| MatchProblem::FilterPrefixes)
+            self.no_match_any_report(|| MatchFilterPrefixes)
         } else {
             None
         }
@@ -120,18 +120,18 @@ impl<'a> CheckFilter<'a> {
 
     fn filter_route_set(&self, name: &str, op: RangeOperator, depth: isize) -> AnyReport {
         if depth <= 0 {
-            return recursion_any_report(RecurSrc::FilterRouteSet(name.into()));
+            return recursion_any_report(RecFilterRouteSet(name.into()));
         }
         let route_set = match self.query.route_sets.get(name) {
             Some(r) => r,
-            None => return self.skip_any_report(|| SkipReason::RouteSetUnrecorded(name.into())),
+            None => return self.skip_any_report(|| SkipRouteSetUnrecorded(name.into())),
         };
         let mut report = SkipFBad::const_default();
         for member in &route_set.members {
             report |= self.filter_route_set_member(member, op, depth - 1)?;
         }
         if let BadF(_) = report {
-            self.no_match_any_report(|| MatchProblem::FilterRouteSet(name.into()))
+            self.no_match_any_report(|| MatchFilterRouteSet(name.into()))
         } else {
             Some(report)
         }
@@ -144,7 +144,7 @@ impl<'a> CheckFilter<'a> {
         depth: isize,
     ) -> AnyReport {
         if depth <= 0 {
-            return recursion_any_report(RecurSrc::FilterRouteSetMember(member.clone()));
+            return recursion_any_report(RecFilterRouteSetMember(Box::new(member.clone())));
         }
         match member {
             RouteSetMember::RSRange(prefix) => match (prefix.range_operator, op) {
@@ -172,11 +172,11 @@ impl<'a> CheckFilter<'a> {
         }
 
         if depth <= 0 {
-            return recursion_any_report(RecurSrc::FilterAsSet(name.into()));
+            return recursion_any_report(RecFilterAsSet(name.into()));
         }
         let as_set_route = match self.query.as_set_routes.get(name) {
             Some(r) => r,
-            None => return self.skip_any_report(|| SkipReason::AsSetRouteUnrecorded(name.into())),
+            None => return self.skip_any_report(|| SkipAsSetRouteUnrecorded(name.into())),
         };
 
         if match_ips(&self.cmp.prefix, &as_set_route.routes, op) {
@@ -203,13 +203,13 @@ impl<'a> CheckFilter<'a> {
         }
 
         if !as_set_route.unrecorded_nums.is_empty() {
-            report |= self.skip_any_report(|| SkipReason::AsSetRouteSomeUnrecorded(name.into()))?;
+            report |= self.skip_any_report(|| SkipAsSetRouteSomeUnrecorded(name.into()))?;
         }
 
         self.maybe_filter_as_set_is_origin(&mut report, as_set_route);
 
         if let BadF(_) = report {
-            self.no_match_any_report(|| MatchProblem::FilterAsSet(name.into(), op))
+            self.no_match_any_report(|| MatchFilterAsSet(name.into(), op))
         } else {
             Some(report)
         }
@@ -220,7 +220,7 @@ impl<'a> CheckFilter<'a> {
         if let Some(last) = self.last_on_path() {
             if as_set_route.contains_member(last) {
                 *report |= self
-                    .special_any_report(|| AsIsOriginButNoRoute(last))
+                    .special_any_report(|| SpecAsIsOriginButNoRoute(last))
                     .expect("special_any_report never returns None");
             }
         }
@@ -237,7 +237,7 @@ impl<'a> CheckFilter<'a> {
             .collect::<Result<Vec<_>, _>>()
         {
             Ok(p) => p,
-            Err(_) => return self.skip_any_report(|| SkipReason::AsRegexPathWithSet),
+            Err(_) => return self.skip_any_report(|| SkipAsRegexPathWithSet),
         };
         AsRegex {
             c: self,
@@ -250,7 +250,7 @@ impl<'a> CheckFilter<'a> {
 
     fn filter_and(&self, left: &'a Filter, right: &'a Filter, depth: isize) -> AllReport {
         if depth <= 0 {
-            return recursion_all_report(RecurSrc::FilterAnd);
+            return recursion_all_report(RecFilterAnd);
         }
         Ok(self.check_filter(left, depth - 1).to_all()?
             & self.check_filter(right, depth).to_all()?)
@@ -258,21 +258,21 @@ impl<'a> CheckFilter<'a> {
 
     fn filter_or(&self, left: &'a Filter, right: &'a Filter, depth: isize) -> AnyReport {
         if depth <= 0 {
-            return recursion_any_report(RecurSrc::FilterOr);
+            return recursion_any_report(RecFilterOr);
         }
         Some(self.check_filter(left, depth - 1)? | self.check_filter(right, depth)?)
     }
 
     fn filter_not(&self, filter: &'a Filter, depth: isize) -> AnyReport {
         if depth <= 0 {
-            return recursion_any_report(RecurSrc::FilterNot);
+            return recursion_any_report(RecFilterNot);
         }
         match self.check_filter(filter, depth) {
             Some(report @ SkipF(_)) | Some(report @ MehF(_)) => {
-                Some(report | self.no_match_any_report(|| MatchProblem::Filter)?)
+                Some(report | self.no_match_any_report(|| MatchFilter)?)
             }
             Some(BadF(_)) => None,
-            None => self.no_match_any_report(|| MatchProblem::Filter),
+            None => self.no_match_any_report(|| MatchFilter),
         }
     }
 
@@ -280,16 +280,14 @@ impl<'a> CheckFilter<'a> {
     /// <https://github.com/SichangHe/parse_rpsl_policy/issues/16>.
     fn filter_community(&self, community: &Call) -> AnyReport {
         if self.cmp.verbosity.record_community {
-            self.skip_any_report(|| {
-                SkipReason::CommunityCheckUnimplemented(Box::new(community.clone()))
-            })
+            self.skip_any_report(|| SkipCommunityCheckUnimplemented(Box::new(community.clone())))
         } else {
             empty_skip_any_report()
         }
     }
 
     fn invalid_filter(&self, reason: &str) -> AnyReport {
-        self.bad_rpsl_any_report(|| RpslError::InvalidFilter(reason.into()))
+        self.bad_rpsl_any_report(|| RpslInvalidFilter(reason.into()))
     }
 
     /// `Err` contains all the skips.
@@ -301,7 +299,7 @@ impl<'a> CheckFilter<'a> {
         visited: &mut BloomHashSet<&'a str>,
     ) -> Result<bool, AnyReport> {
         if depth < 0 {
-            return Err(recursion_any_report(RecurSrc::CheckSetMember(set.into())));
+            return Err(recursion_any_report(RecCheckSetMember(set.into())));
         }
         let hash = visited.make_hash(&set);
         if visited.contains_with_hash(&set, hash) {
@@ -309,7 +307,7 @@ impl<'a> CheckFilter<'a> {
         }
         let as_set = match self.query.as_sets.get(set) {
             Some(s) => s,
-            None => return Err(self.skip_any_report(|| SkipReason::AsSetUnrecorded(set.into()))),
+            None => return Err(self.skip_any_report(|| SkipAsSetUnrecorded(set.into()))),
         };
         if as_set.is_any || as_set.members.contains(&asn) {
             return Ok(true);

--- a/route_verification/bgp/src/cmp/filter.rs
+++ b/route_verification/bgp/src/cmp/filter.rs
@@ -38,7 +38,7 @@ impl<'a> CheckFilter<'a> {
     fn filter_set(&self, name: &str, depth: isize) -> AnyReport {
         let filter_set = match self.query.filter_sets.get(name) {
             Some(f) => f,
-            None => return self.skip_any_report(|| UnrecordedFilterSet(name.into())),
+            None => return self.unrec_any_report(|| UnrecordedFilterSet(name.into())),
         };
         let mut report = AnyReportCase::const_default();
         for filter in &filter_set.filters {
@@ -52,8 +52,8 @@ impl<'a> CheckFilter<'a> {
             Some(r) => r,
             None => {
                 return match self.cmp.goes_through_num(num) {
-                    true => self.skip_any_report(|| UnrecordedAsRoutes(num)),
-                    false => empty_skip_any_report(),
+                    true => self.unrec_any_report(|| UnrecordedAsRoutes(num)),
+                    false => empty_unrec_any_report(),
                 }
             }
         };
@@ -124,7 +124,7 @@ impl<'a> CheckFilter<'a> {
         }
         let route_set = match self.query.route_sets.get(name) {
             Some(r) => r,
-            None => return self.skip_any_report(|| UnrecordedRouteSet(name.into())),
+            None => return self.unrec_any_report(|| UnrecordedRouteSet(name.into())),
         };
         let mut report = AnyReportCase::const_default();
         for member in &route_set.members {
@@ -176,7 +176,7 @@ impl<'a> CheckFilter<'a> {
         }
         let as_set_route = match self.query.as_set_routes.get(name) {
             Some(r) => r,
-            None => return self.skip_any_report(|| UnrecordedAsSetRoute(name.into())),
+            None => return self.unrec_any_report(|| UnrecordedAsSetRoute(name.into())),
         };
 
         if match_ips(&self.cmp.prefix, &as_set_route.routes, op) {
@@ -203,7 +203,7 @@ impl<'a> CheckFilter<'a> {
         }
 
         if !as_set_route.unrecorded_nums.is_empty() {
-            report |= self.skip_any_report(|| UnrecordedSomeAsSetRoute(name.into()))?;
+            report |= self.unrec_any_report(|| UnrecordedSomeAsSetRoute(name.into()))?;
         }
 
         self.maybe_filter_as_set_is_origin(&mut report, as_set_route);
@@ -311,7 +311,7 @@ impl<'a> CheckFilter<'a> {
         }
         let as_set = match self.query.as_sets.get(set) {
             Some(s) => s,
-            None => return Err(self.skip_any_report(|| UnrecordedAsSet(set.into()))),
+            None => return Err(self.unrec_any_report(|| UnrecordedAsSet(set.into()))),
         };
         if as_set.is_any || as_set.members.contains(&asn) {
             return Ok(true);

--- a/route_verification/bgp/src/cmp/filter.rs
+++ b/route_verification/bgp/src/cmp/filter.rs
@@ -272,10 +272,10 @@ impl<'a> CheckFilter<'a> {
             return bad_any_report(RecFilterNot);
         }
         match self.check_filter(filter, depth) {
-            Some(report @ SkipAnyReport(_)) | Some(report @ MehAnyReport(_)) => {
+            Some(report @ SkipAnyReport(_) | report @ UnrecAnyReport(_)) => {
                 Some(report | self.bad_any_report(|| MatchFilter)?)
             }
-            Some(BadAnyReport(_)) => None,
+            Some(MehAnyReport(_) | BadAnyReport(_)) => None,
             None => self.bad_any_report(|| MatchFilter),
         }
     }

--- a/route_verification/bgp/src/cmp/hill.rs
+++ b/route_verification/bgp/src/cmp/hill.rs
@@ -17,15 +17,15 @@ impl Compare {
             BadImport { from, to, items } => match db.get(*to, *from) {
                 Some(P2C) if self.verbosity.special_uphill => {
                     let reason = match db.is_clique(to) {
-                        true => UphillTier1,
-                        false => Uphill,
+                        true => SpecUphillTier1,
+                        false => SpecUphill,
                     };
                     *report = self.meh_import(*from, *to, mem::take(items), reason);
                 }
                 Some(P2P) if self.verbosity.check_import_only_provider => {
                     if let Some(property) = query.as_properties.get(to) {
                         if property.import_only_provider {
-                            let reason = ImportPeerOIFPS;
+                            let reason = SpecImportPeerOIFPS;
                             *report = self.meh_import(*from, *to, mem::take(items), reason);
                         }
                     }
@@ -33,26 +33,26 @@ impl Compare {
                 Some(C2P) if self.verbosity.check_import_only_provider => {
                     if let Some(property) = query.as_properties.get(to) {
                         if property.import_only_provider {
-                            let reason = ImportCustomerOIFPS;
+                            let reason = SpecImportCustomerOIFPS;
                             *report = self.meh_import(*from, *to, mem::take(items), reason);
                         }
                     }
                 }
                 _ if db.is_clique(from) && db.is_clique(to) => {
-                    *report = self.meh_import(*from, *to, mem::take(items), Tier1Pair);
+                    *report = self.meh_import(*from, *to, mem::take(items), SpecTier1Pair);
                 }
                 _ => (),
             },
             BadExport { from, to, items } => match db.get(*to, *from) {
                 Some(P2C) if self.verbosity.special_uphill => {
                     let reason = match db.is_clique(to) {
-                        true => UphillTier1,
-                        false => Uphill,
+                        true => SpecUphillTier1,
+                        false => SpecUphill,
                     };
                     *report = self.meh_export(*from, *to, mem::take(items), reason);
                 }
                 _ if db.is_clique(from) && db.is_clique(to) => {
-                    *report = self.meh_export(*from, *to, mem::take(items), Tier1Pair);
+                    *report = self.meh_export(*from, *to, mem::take(items), SpecTier1Pair);
                 }
                 _ => (),
             },

--- a/route_verification/bgp/src/cmp/peering.rs
+++ b/route_verification/bgp/src/cmp/peering.rs
@@ -51,7 +51,7 @@ impl<'a> CheckPeering<'a> {
 
     fn check_remote_as(&self, remote_as: &AsExpr, depth: isize) -> AnyReport {
         if depth <= 0 {
-            return recursion_any_report(RecurSrc::CheckRemoteAs);
+            return recursion_any_report(RecCheckRemoteAs);
         }
         match remote_as {
             AsExpr::Single(as_name) => self.check_remote_as_name(as_name, depth),
@@ -65,7 +65,7 @@ impl<'a> CheckPeering<'a> {
 
     fn check_remote_as_name(&self, as_name: &AsName, depth: isize) -> AnyReport {
         if depth <= 0 {
-            return recursion_any_report(RecurSrc::RemoteAsName(as_name.clone()));
+            return recursion_any_report(RecRemoteAsName(Box::new(as_name.clone())));
         }
         match as_name {
             AsName::Any => None,
@@ -74,7 +74,7 @@ impl<'a> CheckPeering<'a> {
                 self.check_remote_as_set(name, depth, &mut BloomHashSet::with_capacity(2048, 32768))
             }
             AsName::Invalid(reason) => {
-                self.bad_rpsl_any_report(|| RpslError::InvalidAsName(reason.into()))
+                self.bad_rpsl_any_report(|| RpslInvalidAsName(reason.into()))
             }
         }
     }
@@ -83,7 +83,7 @@ impl<'a> CheckPeering<'a> {
         if self.accept_num == num {
             None
         } else {
-            self.no_match_any_report(|| MatchProblem::RemoteAsNum(num))
+            self.no_match_any_report(|| MatchRemoteAsNum(num))
         }
     }
 
@@ -99,11 +99,11 @@ impl<'a> CheckPeering<'a> {
         }
 
         if depth <= 0 {
-            return recursion_any_report(RecurSrc::RemoteAsSet(name.into()));
+            return recursion_any_report(RecRemoteAsSet(name.into()));
         }
         let as_set = match self.c.query.as_sets.get(name) {
             Some(r) => r,
-            None => return self.skip_any_report(|| SkipReason::AsSetUnrecorded(name.into())),
+            None => return self.skip_any_report(|| SkipAsSetUnrecorded(name.into())),
         };
 
         if as_set.is_any || as_set.members.binary_search(&self.accept_num).is_ok() {
@@ -128,18 +128,18 @@ impl<'a> CheckPeering<'a> {
             report |= self.check_remote_as_set(set, depth - 1, visited)?;
         }
         if let BadF(_) = report {
-            self.no_match_any_report(|| MatchProblem::RemoteAsSet(name.into()))
+            self.no_match_any_report(|| MatchRemoteAsSet(name.into()))
         } else {
             Some(report)
         }
     }
     fn check_remote_peering_set(&self, name: &str, depth: isize) -> AnyReport {
         if depth <= 0 {
-            return recursion_any_report(RecurSrc::RemotePeeringSet(name.into()));
+            return recursion_any_report(RecRemotePeeringSet(name.into()));
         }
         let peering_set = match self.c.query.peering_sets.get(name) {
             Some(r) => r,
-            None => return self.skip_any_report(|| SkipReason::PeeringSetUnrecorded(name.into())),
+            None => return self.skip_any_report(|| SkipPeeringSetUnrecorded(name.into())),
         };
         let mut report = SkipFBad::const_default();
         for peering in &peering_set.peerings {
@@ -150,7 +150,7 @@ impl<'a> CheckPeering<'a> {
 
     fn check_and(&self, left: &AsExpr, right: &AsExpr, depth: isize) -> AllReport {
         if depth <= 0 {
-            return recursion_all_report(RecurSrc::PeeringAnd);
+            return recursion_all_report(RecPeeringAnd);
         }
         Ok(self.check_remote_as(left, depth - 1).to_all()?
             & self.check_remote_as(right, depth).to_all()?)
@@ -158,23 +158,22 @@ impl<'a> CheckPeering<'a> {
 
     fn check_or(&self, left: &AsExpr, right: &AsExpr, depth: isize) -> AnyReport {
         if depth <= 0 {
-            return recursion_any_report(RecurSrc::PeeringOr);
+            return recursion_any_report(RecPeeringOr);
         }
         Some(self.check_remote_as(left, depth - 1)? | self.check_remote_as(right, depth)?)
     }
 
     fn check_except(&self, left: &AsExpr, right: &AsExpr, depth: isize) -> AllReport {
         if depth <= 0 {
-            return recursion_all_report(RecurSrc::PeeringExcept);
+            return recursion_all_report(RecPeeringExcept);
         }
         Ok(self.check_remote_as(left, depth - 1).to_all()?
             & match self.check_remote_as(right, depth) {
                 report @ Some(SkipF(_)) | report @ Some(MehF(_)) => {
-                    report.to_all()?
-                        & self.skip_all_report(|| SkipReason::SkippedExceptPeeringResult)?
+                    report.to_all()? & self.skip_all_report(|| SkipSkippedExceptPeeringResult)?
                 }
                 Some(BadF(_)) => OkT,
-                None => self.no_match_all_report(|| MatchProblem::ExceptPeeringRightMatch)?,
+                None => self.no_match_all_report(|| MatchExceptPeeringRightMatch)?,
             })
     }
 }

--- a/route_verification/bgp/src/cmp/peering.rs
+++ b/route_verification/bgp/src/cmp/peering.rs
@@ -167,10 +167,8 @@ impl<'a> CheckPeering<'a> {
         }
         Ok(self.check_remote_as(left, depth - 1).to_all()?
             & match self.check_remote_as(right, depth) {
-                report @ Some(SkipAnyReport(_)) | report @ Some(MehAnyReport(_)) => {
-                    report.to_all()? & self.skip_all_report(|| SkipSkippedExceptPeeringResult)?
-                }
-                Some(BadAnyReport(_)) => OkAllReport,
+                report @ Some(SkipAnyReport(_) | UnrecAnyReport(_)) => report.to_all()?,
+                Some(MehAnyReport(_) | BadAnyReport(_)) => OkAllReport,
                 None => self.bad_all_report(|| MatchExceptPeeringRight)?,
             })
     }

--- a/route_verification/bgp/src/cmp/peering.rs
+++ b/route_verification/bgp/src/cmp/peering.rs
@@ -101,7 +101,7 @@ impl<'a> CheckPeering<'a> {
         }
         let as_set = match self.c.query.as_sets.get(name) {
             Some(r) => r,
-            None => return self.skip_any_report(|| UnrecordedAsSet(name.into())),
+            None => return self.unrec_any_report(|| UnrecordedAsSet(name.into())),
         };
 
         if as_set.is_any || as_set.members.binary_search(&self.accept_num).is_ok() {
@@ -137,7 +137,7 @@ impl<'a> CheckPeering<'a> {
         }
         let peering_set = match self.c.query.peering_sets.get(name) {
             Some(r) => r,
-            None => return self.skip_any_report(|| UnrecordedPeeringSet(name.into())),
+            None => return self.unrec_any_report(|| UnrecordedPeeringSet(name.into())),
         };
         let mut report = AnyReportCase::const_default();
         for peering in &peering_set.peerings {

--- a/route_verification/bgp/src/cmp/peering.rs
+++ b/route_verification/bgp/src/cmp/peering.rs
@@ -101,7 +101,7 @@ impl<'a> CheckPeering<'a> {
         }
         let as_set = match self.c.query.as_sets.get(name) {
             Some(r) => r,
-            None => return self.skip_any_report(|| SkipAsSetUnrecorded(name.into())),
+            None => return self.skip_any_report(|| UnrecordedAsSet(name.into())),
         };
 
         if as_set.is_any || as_set.members.binary_search(&self.accept_num).is_ok() {
@@ -137,7 +137,7 @@ impl<'a> CheckPeering<'a> {
         }
         let peering_set = match self.c.query.peering_sets.get(name) {
             Some(r) => r,
-            None => return self.skip_any_report(|| SkipPeeringSetUnrecorded(name.into())),
+            None => return self.skip_any_report(|| UnrecordedPeeringSet(name.into())),
         };
         let mut report = SkipFBad::const_default();
         for peering in &peering_set.peerings {

--- a/route_verification/bgp/src/cmp/peering.rs
+++ b/route_verification/bgp/src/cmp/peering.rs
@@ -171,7 +171,7 @@ impl<'a> CheckPeering<'a> {
                     report.to_all()? & self.skip_all_report(|| SkipSkippedExceptPeeringResult)?
                 }
                 Some(BadF(_)) => OkT,
-                None => self.bad_all_report(|| MatchExceptPeeringRightMatch)?,
+                None => self.bad_all_report(|| MatchExceptPeeringRight)?,
             })
     }
 }

--- a/route_verification/bgp/src/lib.rs
+++ b/route_verification/bgp/src/lib.rs
@@ -21,7 +21,7 @@ pub use {
     bgpmap::{self as map, AsPathEntry},
     cmp::Compare,
     query::{customer_set, AsProperty, AsSetRoute, QueryIr},
-    report::{MatchProblem, Report, ReportItem, SkipReason},
+    report::{Report, ReportItem},
     stats::{AsPairStats, AsStats, UpDownHillStats},
     verbosity::Verbosity,
     wrapper::{parse_mrt, Line},

--- a/route_verification/bgp/src/report.rs
+++ b/route_verification/bgp/src/report.rs
@@ -1,7 +1,5 @@
 use std::ops::{BitAnd, BitOr, BitOrAssign};
 
-use ReportItem::*;
-
 use ::lex::Call;
 use parse::*;
 
@@ -102,92 +100,72 @@ impl Report {
 /// Single item in [`Report`] to signal some status.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ReportItem {
-    Skip(SkipReason),
-    Special(SpecialCase),
-    NoMatch(MatchProblem),
-    BadRpsl(RpslError),
-    Recursion(RecurSrc),
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum SkipReason {
-    FilterSetUnrecorded(String),
-    AsRoutesUnrecorded(u64),
-    RouteSetUnrecorded(String),
-    AsSetUnrecorded(String),
-    AsSetRouteUnrecorded(String),
-    AsSetRouteSomeUnrecorded(String),
-    AsRegexWithTilde(String),
-    AsRegexPathWithSet,
-    SkippedNotFilterResult,
-    CommunityCheckUnimplemented(Box<Call>),
-    UnknownFilter(String),
-    PeeringSetUnrecorded(String),
-    SkippedExceptPeeringResult,
-    AutNumUnrecorded(u64),
-    ImportEmpty,
-    ExportEmpty,
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum SpecialCase {
+    // Skip.
+    SkipFilterSetUnrecorded(String),
+    SkipAsRoutesUnrecorded(u64),
+    SkipRouteSetUnrecorded(String),
+    SkipAsSetUnrecorded(String),
+    SkipAsSetRouteUnrecorded(String),
+    SkipAsSetRouteSomeUnrecorded(String),
+    SkipAsRegexWithTilde(String),
+    SkipAsRegexPathWithSet,
+    SkipSkippedNotFilterResult,
+    SkipCommunityCheckUnimplemented(Box<Call>),
+    SkipUnknownFilter(String),
+    SkipPeeringSetUnrecorded(String),
+    SkipSkippedExceptPeeringResult,
+    SkipAutNumUnrecorded(u64),
+    SkipImportEmpty,
+    SkipExportEmpty,
+    // Special case.
     /// Route from customer to provider.
-    Uphill,
+    SpecUphill,
     /// Route from customer to provider that is tier-1.
-    UphillTier1,
+    SpecUphillTier1,
     /// Export customer routes while specifying the AS itself as `<filter>`.
-    ExportCustomers,
+    SpecExportCustomers,
     /// AS in `<filter>` is the origin on the path, but the route mismatches.
-    AsIsOriginButNoRoute(u64),
+    SpecAsIsOriginButNoRoute(u64),
     /// Route between Tier 1 ASes.
-    Tier1Pair,
+    SpecTier1Pair,
     /// Import route between peers while Only Imports From Providers are
     /// Specified (OIFPS).
-    ImportPeerOIFPS,
+    SpecImportPeerOIFPS,
     /// Import route from customer while Only Imports From Providers are
     /// Specified (OIFPS).
-    ImportCustomerOIFPS,
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum MatchProblem {
-    Filter,
-    FilterAsNum(u64, RangeOperator),
-    FilterAsSet(String, RangeOperator),
-    FilterPrefixes,
-    FilterRouteSet(String),
-    RemoteAsNum(u64),
-    RemoteAsSet(String),
-    ExceptPeeringRightMatch,
-    Peering,
-    RegexMismatch(String),
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum RpslError {
-    InvalidAsName(String),
-    InvalidFilter(String),
-    InvalidAsRegex(String),
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum RecurSrc {
-    CheckFilter,
-    FilterRouteSet(String),
-    FilterRouteSetMember(RouteSetMember),
-    FilterAsSet(String),
-    FilterAsName(AsName),
-    FilterAnd,
-    FilterOr,
-    FilterNot,
-    CheckSetMember(String),
-    CheckRemoteAs,
-    RemoteAsName(AsName),
-    RemoteAsSet(String),
-    RemotePeeringSet(String),
-    PeeringAnd,
-    PeeringOr,
-    PeeringExcept,
+    SpecImportCustomerOIFPS,
+    // Match problem.
+    MatchFilter,
+    MatchFilterAsNum(u64, RangeOperator),
+    MatchFilterAsSet(String, RangeOperator),
+    MatchFilterPrefixes,
+    MatchFilterRouteSet(String),
+    MatchRemoteAsNum(u64),
+    MatchRemoteAsSet(String),
+    MatchExceptPeeringRightMatch,
+    MatchPeering,
+    MatchRegexMismatch(String),
+    // Invalid RPSL.
+    RpslInvalidAsName(String),
+    RpslInvalidFilter(String),
+    RpslInvalidAsRegex(String),
+    // Recursion error.
+    RecCheckFilter,
+    RecFilterRouteSet(String),
+    RecFilterRouteSetMember(Box<RouteSetMember>),
+    RecFilterAsSet(String),
+    RecFilterAsName(Box<AsName>),
+    RecFilterAnd,
+    RecFilterOr,
+    RecFilterNot,
+    RecCheckSetMember(String),
+    RecCheckRemoteAs,
+    RecRemoteAsName(Box<AsName>),
+    RecRemoteAsSet(String),
+    RecRemotePeeringSet(String),
+    RecPeeringAnd,
+    RecPeeringOr,
+    RecPeeringExcept,
 }
 
 pub type ReportItems = Vec<ReportItem>;

--- a/route_verification/bgp/src/report.rs
+++ b/route_verification/bgp/src/report.rs
@@ -117,6 +117,7 @@ pub enum ReportItem {
     SkipAutNumUnrecorded(u64),
     SkipImportEmpty,
     SkipExportEmpty,
+
     // Special case.
     /// Route from customer to provider.
     SpecUphill,
@@ -134,6 +135,7 @@ pub enum ReportItem {
     /// Import route from customer while Only Imports From Providers are
     /// Specified (OIFPS).
     SpecImportCustomerOIFPS,
+
     // Match problem.
     MatchFilter,
     MatchFilterAsNum(u64, RangeOperator),
@@ -142,13 +144,15 @@ pub enum ReportItem {
     MatchFilterRouteSet(String),
     MatchRemoteAsNum(u64),
     MatchRemoteAsSet(String),
-    MatchExceptPeeringRightMatch,
+    MatchExceptPeeringRight,
     MatchPeering,
-    MatchRegexMismatch(String),
+    MatchRegex(String),
+
     // Invalid RPSL.
     RpslInvalidAsName(String),
     RpslInvalidFilter(String),
     RpslInvalidAsRegex(String),
+
     // Recursion error.
     RecCheckFilter,
     RecFilterRouteSet(String),

--- a/route_verification/bgp/src/report.rs
+++ b/route_verification/bgp/src/report.rs
@@ -129,10 +129,6 @@ pub enum ReportItem {
     SkipAsRegexPathWithSet,
     SkipCommunityCheckUnimplemented(Box<Call>),
 
-    // Skip skipped.
-    SkipSkippedNotFilterResult,
-    SkipSkippedExceptPeeringResult,
-
     // Skip empty.
     SkipImportEmpty,
     SkipExportEmpty,

--- a/route_verification/bgp/src/report.rs
+++ b/route_verification/bgp/src/report.rs
@@ -10,7 +10,7 @@ mod any;
 
 pub use {all::*, any::*};
 
-use {OkTBad::*, Report::*, SkipFBad::*};
+use {AllReportCase::*, AnyReportCase::*, Report::*};
 
 /// Report about the validity of a route, according to the RPSL.
 /// Use this in an `Option`, and use `None` to indicate "ok."

--- a/route_verification/bgp/src/report.rs
+++ b/route_verification/bgp/src/report.rs
@@ -114,16 +114,6 @@ impl Report {
 /// Single item in [`Report`] to signal some status.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ReportItem {
-    // Skip unrecorded.
-    UnrecordedFilterSet(String),
-    UnrecordedAsRoutes(u64),
-    UnrecordedRouteSet(String),
-    UnrecordedAsSet(String),
-    UnrecordedAsSetRoute(String),
-    UnrecordedSomeAsSetRoute(String),
-    UnrecordedAutNum(u64),
-    UnrecordedPeeringSet(String),
-
     // Skip unimplemented.
     SkipAsRegexWithTilde(String),
     SkipAsRegexPathWithSet,
@@ -132,6 +122,16 @@ pub enum ReportItem {
     // Skip empty.
     SkipImportEmpty,
     SkipExportEmpty,
+
+    // Unrecorded.
+    UnrecordedFilterSet(String),
+    UnrecordedAsRoutes(u64),
+    UnrecordedRouteSet(String),
+    UnrecordedAsSet(String),
+    UnrecordedAsSetRoute(String),
+    UnrecordedSomeAsSetRoute(String),
+    UnrecordedAutNum(u64),
+    UnrecordedPeeringSet(String),
 
     // Special case.
     /// Route from customer to provider.

--- a/route_verification/bgp/src/report.rs
+++ b/route_verification/bgp/src/report.rs
@@ -100,21 +100,26 @@ impl Report {
 /// Single item in [`Report`] to signal some status.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ReportItem {
-    // Skip.
-    SkipFilterSetUnrecorded(String),
-    SkipAsRoutesUnrecorded(u64),
-    SkipRouteSetUnrecorded(String),
-    SkipAsSetUnrecorded(String),
-    SkipAsSetRouteUnrecorded(String),
-    SkipAsSetRouteSomeUnrecorded(String),
+    // Skip unrecorded.
+    UnrecordedFilterSet(String),
+    UnrecordedAsRoutes(u64),
+    UnrecordedRouteSet(String),
+    UnrecordedAsSet(String),
+    UnrecordedAsSetRoute(String),
+    UnrecordedSomeAsSetRoute(String),
+    UnrecordedAutNum(u64),
+    UnrecordedPeeringSet(String),
+
+    // Skip unimplemented.
     SkipAsRegexWithTilde(String),
     SkipAsRegexPathWithSet,
-    SkipSkippedNotFilterResult,
     SkipCommunityCheckUnimplemented(Box<Call>),
-    SkipUnknownFilter(String),
-    SkipPeeringSetUnrecorded(String),
+
+    // Skip skipped.
+    SkipSkippedNotFilterResult,
     SkipSkippedExceptPeeringResult,
-    SkipAutNumUnrecorded(u64),
+
+    // Skip empty.
     SkipImportEmpty,
     SkipExportEmpty,
 
@@ -152,6 +157,7 @@ pub enum ReportItem {
     RpslInvalidAsName(String),
     RpslInvalidFilter(String),
     RpslInvalidAsRegex(String),
+    RpslUnknownFilter(String),
 
     // Recursion error.
     RecCheckFilter,

--- a/route_verification/bgp/src/report.rs
+++ b/route_verification/bgp/src/report.rs
@@ -43,6 +43,20 @@ pub enum Report {
         from: u64,
         items: ReportItems,
     },
+    UnrecImport {
+        from: u64,
+        to: u64,
+        items: ReportItems,
+    },
+    UnrecExport {
+        from: u64,
+        to: u64,
+        items: ReportItems,
+    },
+    UnrecSingleExport {
+        from: u64,
+        items: ReportItems,
+    },
     AsPathPairWithSet {
         from: AsPathEntry,
         to: AsPathEntry,
@@ -74,7 +88,7 @@ pub enum Report {
         to: u64,
         items: ReportItems,
     },
-    BadSingeExport {
+    BadSingleExport {
         from: u64,
         items: ReportItems,
     },

--- a/route_verification/bgp/src/report/all.rs
+++ b/route_verification/bgp/src/report/all.rs
@@ -21,8 +21,8 @@ impl ToAnyReport for AllReport {
     }
 }
 
-pub fn skip_all_report(reason: SkipReason) -> AllReport {
-    let skips = vec![Skip(reason)];
+pub fn skip_all_report(reason: ReportItem) -> AllReport {
+    let skips = vec![reason];
     Ok(SkipT(skips))
 }
 
@@ -30,18 +30,18 @@ pub const fn empty_skip_all_report() -> AllReport {
     Ok(SkipT(vec![]))
 }
 
-pub fn no_match_all_report(reason: MatchProblem) -> AllReport {
-    let errors = vec![NoMatch(reason)];
+pub fn no_match_all_report(reason: ReportItem) -> AllReport {
+    let errors = vec![reason];
     Err(errors)
 }
 
-pub fn bad_rpsl_all_report(reason: RpslError) -> AllReport {
-    let errors = vec![BadRpsl(reason)];
+pub fn bad_rpsl_all_report(reason: ReportItem) -> AllReport {
+    let errors = vec![reason];
     Err(errors)
 }
 
-pub fn recursion_all_report(reason: RecurSrc) -> AllReport {
-    let errors = vec![Recursion(reason)];
+pub fn recursion_all_report(reason: ReportItem) -> AllReport {
+    let errors = vec![reason];
     Err(errors)
 }
 

--- a/route_verification/bgp/src/report/all.rs
+++ b/route_verification/bgp/src/report/all.rs
@@ -1,8 +1,6 @@
 use super::*;
 
 /// Useful if all of the reports need to succeed.
-/// - `Ok(Some(skips))` indicates skip.
-/// - `Ok(None)` indicates success.
 /// - `Err(errors)` indicates failure.
 pub type AllReport = Result<OkTBad, ReportItems>;
 

--- a/route_verification/bgp/src/report/all.rs
+++ b/route_verification/bgp/src/report/all.rs
@@ -13,6 +13,7 @@ impl ToAnyReport for AllReport {
         match self {
             Ok(OkAllReport) => None,
             Ok(SkipAllReport(items)) => Some(SkipAnyReport(items)),
+            Ok(UnrecAllReport(items)) => Some(UnrecAnyReport(items)),
             Ok(MehAllReport(items)) => Some(MehAnyReport(items)),
             Err(items) => Some(BadAnyReport(items)),
         }
@@ -40,6 +41,7 @@ pub const fn empty_bad_all_report() -> AllReport {
 pub enum AllReportCase {
     OkAllReport,
     SkipAllReport(ReportItems),
+    UnrecAllReport(ReportItems),
     MehAllReport(ReportItems),
 }
 
@@ -47,15 +49,20 @@ impl BitAnd for AllReportCase {
     type Output = Self;
 
     /// Merge two `AllReportCase`s based on the rule
-    /// ok → skip → meh.
+    /// ok → skip → unrec → meh.
     fn bitand(self, other: Self) -> Self::Output {
         match (self, other) {
             (OkAllReport, other) => other,
             (we, OkAllReport) => we,
-            (MehAllReport(mut items), SkipAllReport(i) | MehAllReport(i))
-            | (SkipAllReport(mut items), MehAllReport(i)) => {
+            (MehAllReport(mut items), SkipAllReport(i) | UnrecAllReport(i) | MehAllReport(i))
+            | (SkipAllReport(mut items) | UnrecAllReport(mut items), MehAllReport(i)) => {
                 items.extend(i);
                 MehAllReport(items)
+            }
+            (UnrecAllReport(mut items), UnrecAllReport(i) | SkipAllReport(i))
+            | (SkipAllReport(mut items), UnrecAllReport(i)) => {
+                items.extend(i);
+                UnrecAllReport(items)
             }
             (SkipAllReport(mut items), SkipAllReport(i)) => {
                 items.extend(i);

--- a/route_verification/bgp/src/report/all.rs
+++ b/route_verification/bgp/src/report/all.rs
@@ -30,22 +30,12 @@ pub const fn empty_skip_all_report() -> AllReport {
     Ok(SkipT(vec![]))
 }
 
-pub fn no_match_all_report(reason: ReportItem) -> AllReport {
+pub fn bad_all_report(reason: ReportItem) -> AllReport {
     let errors = vec![reason];
     Err(errors)
 }
 
-pub fn bad_rpsl_all_report(reason: ReportItem) -> AllReport {
-    let errors = vec![reason];
-    Err(errors)
-}
-
-pub fn recursion_all_report(reason: ReportItem) -> AllReport {
-    let errors = vec![reason];
-    Err(errors)
-}
-
-pub const fn failed_all_report() -> AllReport {
+pub const fn empty_bad_all_report() -> AllReport {
     Err(vec![])
 }
 

--- a/route_verification/bgp/src/report/all.rs
+++ b/route_verification/bgp/src/report/all.rs
@@ -2,7 +2,7 @@ use super::*;
 
 /// Useful if all of the reports need to succeed.
 /// - `Err(errors)` indicates failure.
-pub type AllReport = Result<OkTBad, ReportItems>;
+pub type AllReport = Result<AllReportCase, ReportItems>;
 
 pub trait ToAnyReport {
     fn to_any(self) -> AnyReport;
@@ -11,21 +11,21 @@ pub trait ToAnyReport {
 impl ToAnyReport for AllReport {
     fn to_any(self) -> AnyReport {
         match self {
-            Ok(OkT) => None,
-            Ok(SkipT(items)) => Some(SkipF(items)),
-            Ok(MehT(items)) => Some(MehF(items)),
-            Err(items) => Some(BadF(items)),
+            Ok(OkAllReport) => None,
+            Ok(SkipAllReport(items)) => Some(SkipAnyReport(items)),
+            Ok(MehAllReport(items)) => Some(MehAnyReport(items)),
+            Err(items) => Some(BadAnyReport(items)),
         }
     }
 }
 
 pub fn skip_all_report(reason: ReportItem) -> AllReport {
     let skips = vec![reason];
-    Ok(SkipT(skips))
+    Ok(SkipAllReport(skips))
 }
 
 pub const fn empty_skip_all_report() -> AllReport {
-    Ok(SkipT(vec![]))
+    Ok(SkipAllReport(vec![]))
 }
 
 pub fn bad_all_report(reason: ReportItem) -> AllReport {
@@ -37,39 +37,39 @@ pub const fn empty_bad_all_report() -> AllReport {
     Err(vec![])
 }
 
-pub enum OkTBad {
-    OkT,
-    SkipT(ReportItems),
-    MehT(ReportItems),
+pub enum AllReportCase {
+    OkAllReport,
+    SkipAllReport(ReportItems),
+    MehAllReport(ReportItems),
 }
 
-impl OkTBad {
+impl AllReportCase {
     pub fn join(self, other: Self) -> Self {
         match self {
-            OkT => other,
-            SkipT(mut items) => {
+            OkAllReport => other,
+            SkipAllReport(mut items) => {
                 match other {
-                    OkT => (),
-                    SkipT(i) | MehT(i) => items.extend(i),
+                    OkAllReport => (),
+                    SkipAllReport(i) | MehAllReport(i) => items.extend(i),
                 };
-                SkipT(items)
+                SkipAllReport(items)
             }
-            MehT(mut items) => match other {
-                OkT => MehT(items),
-                SkipT(i) => {
+            MehAllReport(mut items) => match other {
+                OkAllReport => MehAllReport(items),
+                SkipAllReport(i) => {
                     items.extend(i);
-                    SkipT(items)
+                    SkipAllReport(items)
                 }
-                MehT(i) => {
+                MehAllReport(i) => {
                     items.extend(i);
-                    MehT(items)
+                    MehAllReport(items)
                 }
             },
         }
     }
 }
 
-impl BitAnd for OkTBad {
+impl BitAnd for AllReportCase {
     type Output = Self;
 
     fn bitand(self, rhs: Self) -> Self::Output {

--- a/route_verification/bgp/src/report/any.rs
+++ b/route_verification/bgp/src/report/any.rs
@@ -36,6 +36,15 @@ pub const fn empty_skip_any_report() -> AnyReport {
     Some(SkipAnyReport(vec![]))
 }
 
+pub fn unrec_any_report(reason: ReportItem) -> AnyReport {
+    let unrecordeds = vec![reason];
+    Some(UnrecAnyReport(unrecordeds))
+}
+
+pub const fn empty_unrec_any_report() -> AnyReport {
+    Some(UnrecAnyReport(vec![]))
+}
+
 pub fn special_any_report(reason: ReportItem) -> AnyReport {
     let specials = vec![reason];
     Some(MehAnyReport(specials))

--- a/route_verification/bgp/src/report/any.rs
+++ b/route_verification/bgp/src/report/any.rs
@@ -41,23 +41,13 @@ pub const fn empty_meh_any_report() -> AnyReport {
     Some(MehF(vec![]))
 }
 
-pub fn no_match_any_report(reason: ReportItem) -> AnyReport {
-    let errors = vec![reason];
-    Some(BadF(errors))
-}
-
-pub fn bad_rpsl_any_report(reason: ReportItem) -> AnyReport {
-    let errors = vec![reason];
-    Some(BadF(errors))
-}
-
-pub fn recursion_any_report(reason: ReportItem) -> AnyReport {
+pub fn bad_any_report(reason: ReportItem) -> AnyReport {
     let errors = vec![reason];
     Some(BadF(errors))
 }
 
 /// Empty failed `AnyReport`.
-pub const fn failed_any_report() -> AnyReport {
+pub const fn empty_bad_any_report() -> AnyReport {
     Some(BadF(vec![]))
 }
 

--- a/route_verification/bgp/src/report/any.rs
+++ b/route_verification/bgp/src/report/any.rs
@@ -19,25 +19,21 @@ impl ToAllReport for AnyReport {
     }
 }
 
-pub fn skip_any_report(reason: SkipReason) -> AnyReport {
-    let skips = vec![Skip(reason)];
+pub fn skip_any_report(reason: ReportItem) -> AnyReport {
+    let skips = vec![reason];
     Some(SkipF(skips))
 }
 
-pub fn skip_any_reports<I>(reasons: I) -> AnyReport
-where
-    I: IntoIterator<Item = SkipReason>,
-{
-    let skips = reasons.into_iter().map(Skip).collect();
-    Some(SkipF(skips))
+pub fn skip_any_reports(reasons: ReportItems) -> AnyReport {
+    Some(SkipF(reasons))
 }
 
 pub const fn empty_skip_any_report() -> AnyReport {
     Some(SkipF(vec![]))
 }
 
-pub fn special_any_report(reason: SpecialCase) -> AnyReport {
-    let specials = vec![Special(reason)];
+pub fn special_any_report(reason: ReportItem) -> AnyReport {
+    let specials = vec![reason];
     Some(MehF(specials))
 }
 
@@ -45,18 +41,18 @@ pub const fn empty_meh_any_report() -> AnyReport {
     Some(MehF(vec![]))
 }
 
-pub fn no_match_any_report(reason: MatchProblem) -> AnyReport {
-    let errors = vec![NoMatch(reason)];
+pub fn no_match_any_report(reason: ReportItem) -> AnyReport {
+    let errors = vec![reason];
     Some(BadF(errors))
 }
 
-pub fn bad_rpsl_any_report(reason: RpslError) -> AnyReport {
-    let errors = vec![BadRpsl(reason)];
+pub fn bad_rpsl_any_report(reason: ReportItem) -> AnyReport {
+    let errors = vec![reason];
     Some(BadF(errors))
 }
 
-pub fn recursion_any_report(reason: RecurSrc) -> AnyReport {
-    let errors = vec![Recursion(reason)];
+pub fn recursion_any_report(reason: ReportItem) -> AnyReport {
+    let errors = vec![reason];
     Some(BadF(errors))
 }
 

--- a/route_verification/bgp/src/stats/as_.rs
+++ b/route_verification/bgp/src/stats/as_.rs
@@ -17,6 +17,17 @@ pub fn one(map: &DashMap<u64, AsStats>, report: Report) {
             items: _,
         }
         | SkipSingleExport { from, items: _ } => map.entry(from).or_default().export_skip += 1,
+        UnrecImport {
+            from: _,
+            to,
+            items: _,
+        } => map.entry(to).or_default().import_unrec += 1,
+        UnrecExport {
+            from,
+            to: _,
+            items: _,
+        }
+        | UnrecSingleExport { from, items: _ } => map.entry(from).or_default().export_unrec += 1,
         BadImport {
             from: _,
             to,
@@ -27,7 +38,7 @@ pub fn one(map: &DashMap<u64, AsStats>, report: Report) {
             to: _,
             items: _,
         }
-        | BadSingeExport { from, items: _ } => map.entry(from).or_default().export_err += 1,
+        | BadSingleExport { from, items: _ } => map.entry(from).or_default().export_err += 1,
         MehImport {
             from: _,
             to,
@@ -50,6 +61,8 @@ pub struct AsStats {
     pub export_ok: u32,
     pub import_skip: u32,
     pub export_skip: u32,
+    pub import_unrec: u32,
+    pub export_unrec: u32,
     pub import_meh: u32,
     pub export_meh: u32,
     pub import_err: u32,

--- a/route_verification/bgp/src/stats/as_pair.rs
+++ b/route_verification/bgp/src/stats/as_pair.rs
@@ -11,6 +11,8 @@ pub(crate) fn one(db: &AsRelDb, map: &DashMap<(u64, u64), AsPairStats>, report: 
         OkExport { from, to } => entry(from, to).export_ok += 1,
         SkipImport { from, to, items: _ } => entry(from, to).import_skip += 1,
         SkipExport { from, to, items: _ } => entry(from, to).export_skip += 1,
+        UnrecImport { from, to, items: _ } => entry(from, to).import_unrec += 1,
+        UnrecExport { from, to, items: _ } => entry(from, to).export_unrec += 1,
         BadImport { from, to, items: _ } => entry(from, to).import_err += 1,
         BadExport { from, to, items: _ } => entry(from, to).export_err += 1,
         MehImport { from, to, items: _ } => entry(from, to).import_meh += 1,
@@ -19,8 +21,9 @@ pub(crate) fn one(db: &AsRelDb, map: &DashMap<(u64, u64), AsPairStats>, report: 
         | SetSingleExport { from: _ }
         | OkSingleExport { from: _ }
         | SkipSingleExport { from: _, items: _ }
+        | UnrecSingleExport { from: _, items: _ }
         | MehSingleExport { from: _, items: _ }
-        | BadSingeExport { from: _, items: _ } => (),
+        | BadSingleExport { from: _, items: _ } => (),
     }
 }
 
@@ -31,6 +34,8 @@ pub struct AsPairStats {
     pub export_ok: u32,
     pub import_skip: u32,
     pub export_skip: u32,
+    pub import_unrec: u32,
+    pub export_unrec: u32,
     pub import_meh: u32,
     pub export_meh: u32,
     pub import_err: u32,

--- a/route_verification/bgp/src/stats/up_down_hill.rs
+++ b/route_verification/bgp/src/stats/up_down_hill.rs
@@ -15,19 +15,25 @@ pub fn one(stats: &mut UpDownHillStats, report: &Report, db: &AsRelDb) {
             None => stats.ok_other_export += 1,
         },
         OkSingleExport { from: _ } => stats.ok_other_export += 1,
-        SkipImport { from, to, items: _ } => match db.get(*from, *to) {
-            Some(P2C) => stats.skip_down_import += 1,
-            Some(P2P) => stats.skip_peer_import += 1,
-            Some(C2P) => stats.skip_up_import += 1,
-            None => stats.skip_other_import += 1,
-        },
-        SkipExport { from, to, items: _ } => match db.get(*from, *to) {
-            Some(P2C) => stats.skip_down_export += 1,
-            Some(P2P) => stats.skip_peer_export += 1,
-            Some(C2P) => stats.skip_up_export += 1,
-            None => stats.skip_other_export += 1,
-        },
-        SkipSingleExport { from: _, items: _ } => stats.skip_other_export += 1,
+        SkipImport { from, to, items: _ } | UnrecImport { from, to, items: _ } => {
+            match db.get(*from, *to) {
+                Some(P2C) => stats.skip_down_import += 1,
+                Some(P2P) => stats.skip_peer_import += 1,
+                Some(C2P) => stats.skip_up_import += 1,
+                None => stats.skip_other_import += 1,
+            }
+        }
+        SkipExport { from, to, items: _ } | UnrecExport { from, to, items: _ } => {
+            match db.get(*from, *to) {
+                Some(P2C) => stats.skip_down_export += 1,
+                Some(P2P) => stats.skip_peer_export += 1,
+                Some(C2P) => stats.skip_up_export += 1,
+                None => stats.skip_other_export += 1,
+            }
+        }
+        SkipSingleExport { from: _, items: _ } | UnrecSingleExport { from: _, items: _ } => {
+            stats.skip_other_export += 1
+        }
         BadImport { from, to, items: _ } | MehImport { from, to, items: _ } => {
             match db.get(*from, *to) {
                 Some(P2C) => stats.bad_down_import += 1,
@@ -44,10 +50,10 @@ pub fn one(stats: &mut UpDownHillStats, report: &Report, db: &AsRelDb) {
                 None => stats.bad_other_export += 1,
             }
         }
-        BadSingeExport { from: _, items: _ } => stats.bad_other_export += 1,
-        AsPathPairWithSet { from: _, to: _ }
-        | SetSingleExport { from: _ }
-        | MehSingleExport { from: _, items: _ } => (),
+        BadSingleExport { from: _, items: _ } | MehSingleExport { from: _, items: _ } => {
+            stats.bad_other_export += 1
+        }
+        AsPathPairWithSet { from: _, to: _ } | SetSingleExport { from: _ } => (),
     }
 }
 

--- a/route_verification/bgp/src/tests/as_property.rs
+++ b/route_verification/bgp/src/tests/as_property.rs
@@ -1,6 +1,6 @@
 use super::{cmp::query, *};
 
-use {Report::*, ReportItem::*, SpecialCase::*};
+use {Report::*, ReportItem::*};
 
 const NUM: u64 = 18106;
 
@@ -49,7 +49,7 @@ fn expected_reports() -> Vec<Report> {
         MehImport {
             from: 196844,
             to: 18106,
-            items: vec![Special(ImportPeerOIFPS)],
+            items: vec![SpecImportPeerOIFPS],
         },
     ]
 }

--- a/route_verification/bgp/src/tests/cmp.rs
+++ b/route_verification/bgp/src/tests/cmp.rs
@@ -65,7 +65,7 @@ fn expected_ok_skip_checks() -> [Vec<Report>; 1] {
             to: 2914,
             items: vec![],
         },
-        SkipExport {
+        UnrecExport {
             from: 2914,
             to: 1239,
             items: vec![
@@ -73,17 +73,17 @@ fn expected_ok_skip_checks() -> [Vec<Report>; 1] {
                 UnrecordedAsSetRoute("AS2914:AS-GLOBAL".into()),
             ],
         },
-        SkipImport {
+        UnrecImport {
             from: 2914,
             to: 1239,
             items: vec![UnrecordedAutNum(1239)],
         },
-        SkipExport {
+        UnrecExport {
             from: 1239,
             to: 3130,
             items: vec![UnrecordedAutNum(1239)],
         },
-        SkipImport {
+        UnrecImport {
             from: 1239,
             to: 3130,
             items: vec![UnrecordedAutNum(3130)],
@@ -113,7 +113,7 @@ fn stats() -> Result<()> {
 
 fn expected_stats() -> [HashMap<u64, AsStats>; 1] {
     [
-        hashmap! {1239=> AsStats { import_ok: 0, export_ok: 0, import_skip: 1, export_skip: 1, import_unrec: 0, export_unrec: 0, import_meh: 0, export_meh: 0, import_err: 0, export_err: 0 }, 2914=> AsStats { import_ok: 0, export_ok: 0, import_skip: 0, export_skip: 1, import_unrec: 0, export_unrec: 0, import_meh: 1, export_meh: 0, import_err: 0, export_err: 0 }, 9583=> AsStats { import_ok: 0, export_ok: 0, import_skip: 0, export_skip: 0, import_unrec: 0, export_unrec: 0, import_meh: 0, export_meh: 1, import_err: 0, export_err: 0 }, 3130=> AsStats { import_ok: 0, export_ok: 0, import_skip: 1, export_skip: 0, import_unrec: 0, export_unrec: 0, import_meh: 0, export_meh: 0, import_err: 0, export_err: 0 }},
+        hashmap! {2914=> AsStats { import_ok: 0, export_ok: 0, import_skip: 0, export_skip: 0, import_unrec: 0, export_unrec: 1, import_meh: 1, export_meh: 0, import_err: 0, export_err: 0 }, 3130=> AsStats { import_ok: 0, export_ok: 0, import_skip: 0, export_skip: 0, import_unrec: 1, export_unrec: 0, import_meh: 0, export_meh: 0, import_err: 0, export_err: 0 }, 1239=> AsStats { import_ok: 0, export_ok: 0, import_skip: 0, export_skip: 0, import_unrec: 1, export_unrec: 1, import_meh: 0, export_meh: 0, import_err: 0, export_err: 0 }, 9583=> AsStats { import_ok: 0, export_ok: 0, import_skip: 0, export_skip: 0, import_unrec: 0, export_unrec: 0, import_meh: 0, export_meh: 1, import_err: 0, export_err: 0 }},
     ]
 }
 

--- a/route_verification/bgp/src/tests/cmp.rs
+++ b/route_verification/bgp/src/tests/cmp.rs
@@ -69,24 +69,24 @@ fn expected_ok_skip_checks() -> [Vec<Report>; 1] {
             from: 2914,
             to: 1239,
             items: vec![
-                SkipAsSetUnrecorded("AS-ANY".into()),
-                SkipAsSetRouteUnrecorded("AS2914:AS-GLOBAL".into()),
+                UnrecordedAsSet("AS-ANY".into()),
+                UnrecordedAsSetRoute("AS2914:AS-GLOBAL".into()),
             ],
         },
         SkipImport {
             from: 2914,
             to: 1239,
-            items: vec![SkipAutNumUnrecorded(1239)],
+            items: vec![UnrecordedAutNum(1239)],
         },
         SkipExport {
             from: 1239,
             to: 3130,
-            items: vec![SkipAutNumUnrecorded(1239)],
+            items: vec![UnrecordedAutNum(1239)],
         },
         SkipImport {
             from: 1239,
             to: 3130,
-            items: vec![SkipAutNumUnrecorded(3130)],
+            items: vec![UnrecordedAutNum(3130)],
         },
     ]]
 }

--- a/route_verification/bgp/src/tests/cmp.rs
+++ b/route_verification/bgp/src/tests/cmp.rs
@@ -2,7 +2,7 @@ use dashmap::DashMap;
 use maplit::hashmap;
 use parse::*;
 
-use crate::{Report::*, ReportItem::*, SkipReason::*, *};
+use crate::{Report::*, ReportItem::*, *};
 
 use super::*;
 
@@ -69,24 +69,24 @@ fn expected_ok_skip_checks() -> [Vec<Report>; 1] {
             from: 2914,
             to: 1239,
             items: vec![
-                Skip(AsSetUnrecorded("AS-ANY".into())),
-                Skip(AsSetRouteUnrecorded("AS2914:AS-GLOBAL".into())),
+                SkipAsSetUnrecorded("AS-ANY".into()),
+                SkipAsSetRouteUnrecorded("AS2914:AS-GLOBAL".into()),
             ],
         },
         SkipImport {
             from: 2914,
             to: 1239,
-            items: vec![Skip(AutNumUnrecorded(1239))],
+            items: vec![SkipAutNumUnrecorded(1239)],
         },
         SkipExport {
             from: 1239,
             to: 3130,
-            items: vec![Skip(AutNumUnrecorded(1239))],
+            items: vec![SkipAutNumUnrecorded(1239)],
         },
         SkipImport {
             from: 1239,
             to: 3130,
-            items: vec![Skip(AutNumUnrecorded(3130))],
+            items: vec![SkipAutNumUnrecorded(3130)],
         },
     ]]
 }

--- a/route_verification/bgp/src/tests/cmp.rs
+++ b/route_verification/bgp/src/tests/cmp.rs
@@ -113,7 +113,7 @@ fn stats() -> Result<()> {
 
 fn expected_stats() -> [HashMap<u64, AsStats>; 1] {
     [
-        hashmap! {3130=> AsStats { import_ok: 0, export_ok: 0, import_skip: 1, export_skip: 0, import_meh: 0, export_meh: 0, import_err: 0, export_err: 0 }, 2914=> AsStats { import_ok: 0, export_ok: 0, import_skip: 0, export_skip: 1, import_meh: 1, export_meh: 0, import_err: 0, export_err: 0 }, 1239=> AsStats { import_ok: 0, export_ok: 0, import_skip: 1, export_skip: 1, import_meh: 0, export_meh: 0, import_err: 0, export_err: 0 }, 9583=> AsStats { import_ok: 0, export_ok: 0, import_skip: 0, export_skip: 0, import_meh: 0, export_meh: 1, import_err: 0, export_err: 0 }},
+        hashmap! {1239=> AsStats { import_ok: 0, export_ok: 0, import_skip: 1, export_skip: 1, import_unrec: 0, export_unrec: 0, import_meh: 0, export_meh: 0, import_err: 0, export_err: 0 }, 2914=> AsStats { import_ok: 0, export_ok: 0, import_skip: 0, export_skip: 1, import_unrec: 0, export_unrec: 0, import_meh: 1, export_meh: 0, import_err: 0, export_err: 0 }, 9583=> AsStats { import_ok: 0, export_ok: 0, import_skip: 0, export_skip: 0, import_unrec: 0, export_unrec: 0, import_meh: 0, export_meh: 1, import_err: 0, export_err: 0 }, 3130=> AsStats { import_ok: 0, export_ok: 0, import_skip: 1, export_skip: 0, import_unrec: 0, export_unrec: 0, import_meh: 0, export_meh: 0, import_err: 0, export_err: 0 }},
     ]
 }
 

--- a/route_verification/bgp/src/tests/psedo_set.rs
+++ b/route_verification/bgp/src/tests/psedo_set.rs
@@ -36,7 +36,7 @@ fn expected_reports_with_customers() -> Vec<Report> {
         SkipImport {
             from: 45891,
             to: 139609,
-            items: vec![SkipAutNumUnrecorded(139609)],
+            items: vec![UnrecordedAutNum(139609)],
         },
     ]
 }

--- a/route_verification/bgp/src/tests/psedo_set.rs
+++ b/route_verification/bgp/src/tests/psedo_set.rs
@@ -22,7 +22,7 @@ fn export_customers() -> Result<()> {
         verbosity,
     };
     let actual = cmp.check(&query);
-    assert_eq!(actual, expected_reports_with_customers());
+    assert_eq!(expected_reports_with_customers(), actual);
     Ok(())
 }
 
@@ -33,7 +33,7 @@ fn expected_reports_with_customers() -> Vec<Report> {
             to: 139609,
             items: vec![SpecExportCustomers],
         },
-        SkipImport {
+        UnrecImport {
             from: 45891,
             to: 139609,
             items: vec![UnrecordedAutNum(139609)],

--- a/route_verification/bgp/src/tests/psedo_set.rs
+++ b/route_verification/bgp/src/tests/psedo_set.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use {AsPathEntry::Seq, Report::*, ReportItem::*, SkipReason::*, SpecialCase::*};
+use {AsPathEntry::Seq, Report::*, ReportItem::*};
 
 const IR: &str = r#"{"aut_nums":{"45891":{"body":"","imports":{"any":{"any":[{"mp_peerings":[{"mp_peering":{"remote_as":{"Single":{"Set":"AS45891:AS-CUSTOMERS"}}}}],"mp_filter":"Any"}]}},"exports":{"any":{"any":[{"mp_peerings":[{"mp_peering":{"remote_as":{"Single":{"Num":139609}}}}],"mp_filter":{"AsNum":[45891,"NoOp"]}},{"mp_peerings":[{"mp_peering":{"remote_as":{"Single":{"Num":60725}}}}],"mp_filter":{"AsNum":[45891,"NoOp"]}}]}}}},"as_sets":{},"route_sets":{},"peering_sets":{},"filter_sets":{},"as_routes":{"134525":["103.2.88.0/24"],"45891":[]}}"#;
 
@@ -31,12 +31,12 @@ fn expected_reports_with_customers() -> Vec<Report> {
         MehExport {
             from: 45891,
             to: 139609,
-            items: vec![Special(ExportCustomers)],
+            items: vec![SpecExportCustomers],
         },
         SkipImport {
             from: 45891,
             to: 139609,
-            items: vec![Skip(AutNumUnrecorded(139609))],
+            items: vec![SkipAutNumUnrecorded(139609)],
         },
     ]
 }

--- a/route_verification/bgp/src/verbosity.rs
+++ b/route_verification/bgp/src/verbosity.rs
@@ -150,6 +150,17 @@ pub trait VerbosityReport {
         }
     }
 
+    fn unrec_any_report<F>(&self, reason: F) -> AnyReport
+    where
+        F: Fn() -> ReportItem,
+    {
+        if self.get_verbosity().show_skips {
+            unrec_any_report(reason())
+        } else {
+            empty_unrec_any_report()
+        }
+    }
+
     fn special_any_report<F>(&self, reason: F) -> AnyReport
     where
         F: Fn() -> ReportItem,

--- a/route_verification/bgp/src/verbosity.rs
+++ b/route_verification/bgp/src/verbosity.rs
@@ -1,8 +1,7 @@
 use super::*;
 
-use ReportItem::*;
 #[allow(unused)] // For the doc.
-use {Report::*, SkipReason::*};
+use Report::*;
 
 /// Verbosity level.
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -109,35 +108,23 @@ impl Default for Verbosity {
 pub trait VerbosityReport {
     fn get_verbosity(&self) -> Verbosity;
 
-    fn meh_import(
-        &self,
-        from: u64,
-        to: u64,
-        mut items: ReportItems,
-        reason: SpecialCase,
-    ) -> Report {
+    fn meh_import(&self, from: u64, to: u64, mut items: ReportItems, reason: ReportItem) -> Report {
         if self.get_verbosity().show_meh {
-            items.push(Special(reason))
+            items.push(reason)
         }
         MehImport { from, to, items }
     }
 
-    fn meh_export(
-        &self,
-        from: u64,
-        to: u64,
-        mut items: ReportItems,
-        reason: SpecialCase,
-    ) -> Report {
+    fn meh_export(&self, from: u64, to: u64, mut items: ReportItems, reason: ReportItem) -> Report {
         if self.get_verbosity().show_meh {
-            items.push(Special(reason))
+            items.push(reason)
         }
         MehExport { from, to, items }
     }
 
     fn skip_any_report<F>(&self, reason: F) -> AnyReport
     where
-        F: Fn() -> SkipReason,
+        F: Fn() -> ReportItem,
     {
         if self.get_verbosity().show_skips {
             skip_any_report(reason())
@@ -146,10 +133,9 @@ pub trait VerbosityReport {
         }
     }
 
-    fn skip_any_reports<F, I>(&self, reasons: F) -> AnyReport
+    fn skip_any_reports<F>(&self, reasons: F) -> AnyReport
     where
-        F: Fn() -> I,
-        I: IntoIterator<Item = SkipReason>,
+        F: Fn() -> ReportItems,
     {
         if self.get_verbosity().show_skips {
             skip_any_reports(reasons())
@@ -160,7 +146,7 @@ pub trait VerbosityReport {
 
     fn special_any_report<F>(&self, reason: F) -> AnyReport
     where
-        F: Fn() -> SpecialCase,
+        F: Fn() -> ReportItem,
     {
         if self.get_verbosity().show_meh {
             special_any_report(reason())
@@ -171,7 +157,7 @@ pub trait VerbosityReport {
 
     fn no_match_any_report<F>(&self, reason: F) -> AnyReport
     where
-        F: Fn() -> MatchProblem,
+        F: Fn() -> ReportItem,
     {
         if self.get_verbosity().all_err {
             no_match_any_report(reason())
@@ -182,7 +168,7 @@ pub trait VerbosityReport {
 
     fn bad_rpsl_any_report<F>(&self, reason: F) -> AnyReport
     where
-        F: Fn() -> RpslError,
+        F: Fn() -> ReportItem,
     {
         if self.get_verbosity().all_err {
             bad_rpsl_any_report(reason())
@@ -193,7 +179,7 @@ pub trait VerbosityReport {
 
     fn skip_all_report<F>(&self, reason: F) -> AllReport
     where
-        F: Fn() -> SkipReason,
+        F: Fn() -> ReportItem,
     {
         if self.get_verbosity().show_skips {
             skip_all_report(reason())
@@ -204,7 +190,7 @@ pub trait VerbosityReport {
 
     fn no_match_all_report<F>(&self, reason: F) -> AllReport
     where
-        F: Fn() -> MatchProblem,
+        F: Fn() -> ReportItem,
     {
         if self.get_verbosity().all_err {
             no_match_all_report(reason())
@@ -215,7 +201,7 @@ pub trait VerbosityReport {
 
     fn bad_rpsl_all_report<F>(&self, reason: F) -> AllReport
     where
-        F: Fn() -> RpslError,
+        F: Fn() -> ReportItem,
     {
         if self.get_verbosity().all_err {
             bad_rpsl_all_report(reason())

--- a/route_verification/bgp/src/verbosity.rs
+++ b/route_verification/bgp/src/verbosity.rs
@@ -10,6 +10,8 @@ pub struct Verbosity {
     pub stop_at_first: bool,
     /// Report meh, or special cases.
     pub show_meh: bool,
+    /// Report unrecorded.
+    pub show_unrec: bool,
     /// Report skips.
     pub show_skips: bool,
     /// Report success.
@@ -36,6 +38,7 @@ impl std::fmt::Debug for Verbosity {
         let Verbosity {
             stop_at_first,
             show_meh,
+            show_unrec,
             show_skips,
             show_success,
             per_entry_err,
@@ -49,6 +52,7 @@ impl std::fmt::Debug for Verbosity {
         for (is_true, tag) in [
             (stop_at_first, "stop_at_first"),
             (show_meh, "show_meh"),
+            (show_unrec, "show_unrec"),
             (show_skips, "show_skips"),
             (show_success, "show_success"),
             (per_entry_err, "per_entry_err"),
@@ -73,6 +77,7 @@ impl Verbosity {
         Self {
             stop_at_first: false,
             show_meh: true,
+            show_unrec: true,
             show_skips: true,
             show_success: true,
             special_uphill: true,
@@ -86,6 +91,7 @@ impl Verbosity {
         Self {
             stop_at_first: true,
             show_meh: false,
+            show_unrec: false,
             show_skips: false,
             show_success: false,
             per_entry_err: false,

--- a/route_verification/bgp/src/verbosity.rs
+++ b/route_verification/bgp/src/verbosity.rs
@@ -155,25 +155,14 @@ pub trait VerbosityReport {
         }
     }
 
-    fn no_match_any_report<F>(&self, reason: F) -> AnyReport
+    fn bad_any_report<F>(&self, reason: F) -> AnyReport
     where
         F: Fn() -> ReportItem,
     {
         if self.get_verbosity().all_err {
-            no_match_any_report(reason())
+            bad_any_report(reason())
         } else {
-            failed_any_report()
-        }
-    }
-
-    fn bad_rpsl_any_report<F>(&self, reason: F) -> AnyReport
-    where
-        F: Fn() -> ReportItem,
-    {
-        if self.get_verbosity().all_err {
-            bad_rpsl_any_report(reason())
-        } else {
-            failed_any_report()
+            empty_bad_any_report()
         }
     }
 
@@ -188,25 +177,14 @@ pub trait VerbosityReport {
         }
     }
 
-    fn no_match_all_report<F>(&self, reason: F) -> AllReport
+    fn bad_all_report<F>(&self, reason: F) -> AllReport
     where
         F: Fn() -> ReportItem,
     {
         if self.get_verbosity().all_err {
-            no_match_all_report(reason())
+            bad_all_report(reason())
         } else {
-            failed_all_report()
-        }
-    }
-
-    fn bad_rpsl_all_report<F>(&self, reason: F) -> AllReport
-    where
-        F: Fn() -> ReportItem,
-    {
-        if self.get_verbosity().all_err {
-            bad_rpsl_all_report(reason())
-        } else {
-            failed_all_report()
+            empty_bad_all_report()
         }
     }
 }

--- a/route_verification/src/evcxr_examples/as_stats.rs
+++ b/route_verification/src/evcxr_examples/as_stats.rs
@@ -14,9 +14,10 @@ fn gen_as_pair_stats(query: QueryIr, mut bgp_lines: Vec<Line>, db: AsRelDb) -> R
         start.elapsed().as_millis()
     );
 
-    let (froms, tos, ioks, eoks, isps, esps, imhs, emhs, iers, eers, rels): (
-        Vec<u64>,
-        Vec<u64>,
+    let (from_tos, ioks, eoks, isps, esps, iurs, eurs, imhs, emhs, iers, eers, rels): (
+        Vec<(u64, u64)>,
+        Vec<u32>,
+        Vec<u32>,
         Vec<u32>,
         Vec<u32>,
         Vec<u32>,
@@ -34,6 +35,8 @@ fn gen_as_pair_stats(query: QueryIr, mut bgp_lines: Vec<Line>, db: AsRelDb) -> R
                 export_ok,
                 import_skip,
                 export_skip,
+                import_unrec,
+                export_unrec,
                 import_meh,
                 export_meh,
                 import_err,
@@ -42,12 +45,13 @@ fn gen_as_pair_stats(query: QueryIr, mut bgp_lines: Vec<Line>, db: AsRelDb) -> R
             },
         )| {
             (
-                from,
-                to,
+                (from, to),
                 import_ok,
                 export_ok,
                 import_skip,
                 export_skip,
+                import_unrec,
+                export_unrec,
                 import_meh,
                 export_meh,
                 import_err,
@@ -61,6 +65,7 @@ fn gen_as_pair_stats(query: QueryIr, mut bgp_lines: Vec<Line>, db: AsRelDb) -> R
             )
         },
     ));
+    let (froms, tos): (Vec<u64>, Vec<u64>) = multiunzip(from_tos);
 
     let mut df: DataFrame = DataFrame::new(vec![
         Series::new("from", froms),
@@ -69,6 +74,8 @@ fn gen_as_pair_stats(query: QueryIr, mut bgp_lines: Vec<Line>, db: AsRelDb) -> R
         Series::new("export_ok", eoks),
         Series::new("import_skip", isps),
         Series::new("export_skip", esps),
+        Series::new("import_unrec", iurs),
+        Series::new("export_unrec", eurs),
         Series::new("import_meh", imhs),
         Series::new("export_meh", emhs),
         Series::new("import_err", iers),
@@ -170,8 +177,10 @@ fn gen_as_stats(query: QueryIr, mut bgp_lines: Vec<Line>, db: AsRelDb) -> Result
         "Generated stats for {size} AS in {}ms.",
         start.elapsed().as_millis()
     );
-    let (ans, ioks, eoks, isps, esps, imhs, emhs, iers, eers): (
+    let (ans, ioks, eoks, isps, esps, iurs, eurs, imhs, emhs, iers, eers): (
         Vec<u64>,
+        Vec<u32>,
+        Vec<u32>,
         Vec<u32>,
         Vec<u32>,
         Vec<u32>,
@@ -188,6 +197,8 @@ fn gen_as_stats(query: QueryIr, mut bgp_lines: Vec<Line>, db: AsRelDb) -> Result
                 export_ok,
                 import_skip,
                 export_skip,
+                import_unrec,
+                export_unrec,
                 import_meh,
                 export_meh,
                 import_err,
@@ -200,6 +211,8 @@ fn gen_as_stats(query: QueryIr, mut bgp_lines: Vec<Line>, db: AsRelDb) -> Result
                 export_ok,
                 import_skip,
                 export_skip,
+                import_unrec,
+                export_unrec,
                 import_meh,
                 export_meh,
                 import_err,
@@ -214,6 +227,8 @@ fn gen_as_stats(query: QueryIr, mut bgp_lines: Vec<Line>, db: AsRelDb) -> Result
         Series::new("export_ok", eoks),
         Series::new("import_skip", isps),
         Series::new("export_skip", esps),
+        Series::new("import_unrec", iurs),
+        Series::new("export_unrec", eurs),
         Series::new("import_meh", imhs),
         Series::new("export_meh", emhs),
         Series::new("import_err", iers),


### PR DESCRIPTION
Fix #65.

Flattening `ReportItem` makes little difference programmatically, but it greatly simplifies shifting the categories of the reports and helps reduce `ReportItem`'s size from 5 to 4 words.

- [x] `UnknownFilter` is an RPSL error.
- [x] More intuitive naming for `SkipFBad`, etc..
- [x] Reorder `AnyReport` to flow unidirectionally ok → skip → unrecorded → meh.
- [x] `Report::UnrecordedImport`, etc. and the "unrecorded" case in `AllReport` and `AnyReport`.
- [x] Remove skipping skipped.