### PR TITLE
Fix IRR priority merging

### DIFF
--- a/route_verification/bloom/src/lib.rs
+++ b/route_verification/bloom/src/lib.rs
@@ -93,10 +93,7 @@ fn make_hash<K>(hash_builder: &DefaultHashBuilder, val: &K) -> u64
 where
     K: Hash,
 {
-    use core::hash::Hasher;
-    let mut state = hash_builder.build_hasher();
-    val.hash(&mut state);
-    state.finish()
+    hash_builder.hash_one(val)
 }
 
 impl<K> BloomHashSet<K>

--- a/route_verification/ir/src/tests.rs
+++ b/route_verification/ir/src/tests.rs
@@ -41,7 +41,6 @@ fn merge_as_routes() -> Result<()> {
         route_sets: BTreeMap::new(),
         peering_sets: BTreeMap::new(),
         filter_sets: BTreeMap::new(),
-        // list of IP prefixes
         as_routes: [
             (
                 1,

--- a/route_verification/ir/src/tests.rs
+++ b/route_verification/ir/src/tests.rs
@@ -12,3 +12,86 @@ fn ipv6_addr_prefix_range() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn merge_as_routes() -> Result<()> {
+    let actual = Ir {
+        aut_nums: BTreeMap::new(),
+        as_sets: BTreeMap::new(),
+        route_sets: BTreeMap::new(),
+        peering_sets: BTreeMap::new(),
+        filter_sets: BTreeMap::new(),
+        as_routes: [
+            (
+                1,
+                vec![
+                    "10.1.1.0/24".parse()?,
+                    "10.1.2.0/24".parse()?,
+                    "10.1.3.0/24".parse()?,
+                ],
+            ),
+            (2, vec!["10.2.1.0/24".parse()?, "10.2.2.0/24".parse()?]),
+            (3, vec!["10.3.1.0/24".parse()?]),
+        ]
+        .into(),
+    }
+    .merge(Ir {
+        aut_nums: BTreeMap::new(),
+        as_sets: BTreeMap::new(),
+        route_sets: BTreeMap::new(),
+        peering_sets: BTreeMap::new(),
+        filter_sets: BTreeMap::new(),
+        // list of IP prefixes
+        as_routes: [
+            (
+                1,
+                vec!["192.168.1.0/24".parse()?, "192.168.2.0/24".parse()?],
+            ),
+            (
+                2,
+                vec![
+                    "192.169.1.0/24".parse()?,
+                    "192.169.2.0/24".parse()?,
+                    "192.169.3.0/24".parse()?,
+                ],
+            ),
+        ]
+        .into(),
+    });
+
+    let expected = Ir {
+        aut_nums: BTreeMap::new(),
+        as_sets: BTreeMap::new(),
+        route_sets: BTreeMap::new(),
+        peering_sets: BTreeMap::new(),
+        filter_sets: BTreeMap::new(),
+        as_routes: [
+            (
+                1,
+                vec![
+                    "10.1.1.0/24".parse()?,
+                    "10.1.2.0/24".parse()?,
+                    "10.1.3.0/24".parse()?,
+                    "192.168.1.0/24".parse()?,
+                    "192.168.2.0/24".parse()?,
+                ],
+            ),
+            (
+                2,
+                vec![
+                    "10.2.1.0/24".parse()?,
+                    "10.2.2.0/24".parse()?,
+                    "192.169.1.0/24".parse()?,
+                    "192.169.2.0/24".parse()?,
+                    "192.169.3.0/24".parse()?,
+                ],
+            ),
+            (3, vec!["10.3.1.0/24".parse()?]),
+        ]
+        .into(),
+    };
+
+    assert_eq!(expected, actual);
+
+    Ok(())
+}

--- a/route_verification/src/lib.rs
+++ b/route_verification/src/lib.rs
@@ -47,18 +47,16 @@ pub fn parse_all(args: Vec<String>) -> Result<()> {
 }
 
 pub fn parse_priority(args: Vec<String>) -> Result<()> {
-    if args.len() < 5 {
-        bail!("Specify a priority directory to read from, a backup directory to read from, and a directory to write to!");
+    if args.len() < 4 {
+        bail!("Specify directories to read from in descending order of priorities, and a directory to write to!");
     }
 
-    let priority_dir = &args[2];
-    debug!("Will read from {priority_dir} as priority.");
-    let backup_dir = &args[3];
-    debug!("Will read from {backup_dir} as backup.");
-    let output_dir = &args[4];
+    let input_dirs = &args[2..args.len() - 1];
+    debug!("Will read from {:?}.", input_dirs);
+    let output_dir = &args.last().expect("`args.len() >= 5`");
     debug!("Will dump to {output_dir}.");
 
-    fs::parse_priority(priority_dir, backup_dir, output_dir)
+    fs::parse_priority(input_dirs, output_dir)
 }
 
 pub fn report(args: Vec<String>) -> Result<()> {


### PR DESCRIPTION
- Merge routes of each AS while merging `IR::as_routes`s.
- Binary (script) allow multiple input IRR directories.