### PR TITLE
Enrich the AS rules CDF plot

### DIFF
--- a/scripts/scripts/csv_files.py
+++ b/scripts/scripts/csv_files.py
@@ -1076,3 +1076,9 @@ transit_as_stats = CsvFile(
     "https://github.com/SichangHe/internet_route_verification/files/14917813/transit_as_stats2.csv",
 )
 """From <https://github.com/SichangHe/internet_route_verification/issues/134#issuecomment-2028748974>."""
+
+as_compatible_with_bgpq3 = CsvFile(
+    "as_compatible_with_bgpq3.csv",
+    "https://github.com/SichangHe/internet_route_verification/files/12906608/as_compatible_with_bgpq3.csv",
+)
+"""From <https://github.com/SichangHe/internet_route_verification/issues/64>."""

--- a/scripts/scripts/fig/as_rules_cdf.py
+++ b/scripts/scripts/fig/as_rules_cdf.py
@@ -58,12 +58,22 @@ def plot() -> tuple[Figure, Axes]:
 
     tier1labels, tier1cdf_data, tier1cum_weights = [], [], []
     giant_labels, giant_cdf_data, giant_cum_weights = [], [], []
+    tier1s_wo_aut_num = {aut_num for aut_num in TIER1S}
+    tier1s_w0rule: set[int] = set()
+    giants_wo_aut_num = {aut_num for aut_num in GIANTS}
+    giants_w0rule: set[int] = set()
     for aut_num, n_rules, cum_weight in zip(aut_num_sorted, cdf_data, cum_weights):
         if aut_num in TIER1S:
+            if n_rules == 0:
+                tier1s_w0rule.add(aut_num)
+            tier1s_wo_aut_num.remove(aut_num)
             tier1labels.append(f"AS{aut_num}")
             tier1cdf_data.append(n_rules)
             tier1cum_weights.append(cum_weight)
         elif aut_num in GIANTS:
+            giants_wo_aut_num.remove(aut_num)
+            if n_rules == 0:
+                giants_w0rule.add(aut_num)
             label = f"AS{aut_num} ({GIANTS[aut_num]})"
             try:
                 index = giant_cdf_data.index(n_rules)
@@ -72,6 +82,13 @@ def plot() -> tuple[Figure, Axes]:
                 giant_labels.append(label)
                 giant_cdf_data.append(n_rules)
                 giant_cum_weights.append(cum_weight)
+
+    print(
+        f"""Tier-1 ASes without aut-num: {tier1s_wo_aut_num}.
+Tier-1 ASes with 0 rule: {tier1s_w0rule}.
+Large cloud providers without aut-num: {giants_wo_aut_num}.
+Large cloud providers with 0 rule: {giants_w0rule}."""
+    )
 
     cdf_data = np.concatenate((cdf_data, np.asarray((cdf_data[-1],))))
     cum_weights = np.concatenate((np.asarray((1,)), cum_weights))

--- a/scripts/scripts/fig/as_rules_cdf.py
+++ b/scripts/scripts/fig/as_rules_cdf.py
@@ -64,8 +64,8 @@ def plot() -> tuple[Figure, Axes]:
         "as_compatible_w_bgpq3"
     ]
     assert isinstance(bgpq3_compatible, pd.Series)
-    df_bgpq3_compatible = df[df["aut_num"].isin(bgpq3_compatible)]
-    df_incompatible = df[~df["aut_num"].isin(bgpq3_compatible)]
+    df_bgpq3_compatible = df[df["aut_num"].isin(bgpq3_compatible) & (df["rules"] > 0)]
+    df_incompatible = df[~df["aut_num"].isin(bgpq3_compatible) & (df["rules"] > 0)]
 
     fig: Figure
     ax: Axes
@@ -109,6 +109,7 @@ def plot() -> tuple[Figure, Axes]:
             textcoords="offset points",
             xytext=(-35, -30),  # Modify this to move text around.
             ha="center",
+            zorder=100,
         )
     ax.set_xscale("log")
     ax.set_yscale("log")

--- a/scripts/scripts/fig/as_rules_cdf.py
+++ b/scripts/scripts/fig/as_rules_cdf.py
@@ -3,10 +3,10 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
+from numpy.typing import NDArray
 import pandas as pd
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
-from pandas.core.frame import com
 
 from scripts import download_csv_files_if_missing
 from scripts.csv_files import as_compatible_with_bgpq3, as_neighbors_vs_rules
@@ -51,15 +51,21 @@ def plot() -> tuple[Figure, Axes]:
     df["rules"] = df["import"] + df["export"]
 
     # CCDF plotting reference: `matplotlib/axes/_axes.py`.
-    cdf_data = np.asarray(df["rules"])
+    cdf_data: NDArray[np.floating] = np.asarray(df["rules"])
     cdf_order = np.argsort(cdf_data)
     cdf_data = cdf_data[cdf_order]
-    aut_num_sorted = np.asarray(df["aut_num"])[cdf_order]
+    aut_num_sorted: NDArray[np.integer] = np.asarray(df["aut_num"])[cdf_order]
     cum_weights = 1 - ((1 + np.arange(len(cdf_data))) / len(cdf_data))
 
     # Tier-1 and large cloud providers scatter plot data.
-    tier1labels, tier1cdf_data, tier1cum_weights = [], [], []
-    giant_labels, giant_cdf_data, giant_cum_weights = [], [], []
+    tier1labels: list[str] = []
+    tier1cdf_data: list[int] = []
+    tier1cum_weights: list[float] = []
+
+    giant_labels: list[str] = []
+    giant_cdf_data: list[int] = []
+
+    giant_cum_weights: list[float] = []
     tier1s_wo_aut_num = {aut_num for aut_num in TIER1S}
     tier1s_w0rule: set[int] = set()
     giants_wo_aut_num = {aut_num for aut_num in GIANTS}

--- a/scripts/scripts/fig/as_rules_cdf.py
+++ b/scripts/scripts/fig/as_rules_cdf.py
@@ -3,10 +3,10 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy.typing import NDArray
 import pandas as pd
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from numpy.typing import NDArray
 
 from scripts import download_csv_files_if_missing
 from scripts.csv_files import as_compatible_with_bgpq3, as_neighbors_vs_rules
@@ -181,24 +181,34 @@ Large cloud providers with 0 rule: {giants_w0rule}."""
             zorder=100,
         )
 
-    ax.scatter(
-        giant_cdf_data,
-        giant_cum_weights,
-        c="purple",
-        s=200,
-        marker="^",
-        linewidth=2,
+    ax.scatter(  # Dummy plot to add legend entry.
+        [],
+        [],
+        c="blueviolet",
+        s=400,
+        linewidth=4,
+        marker=r"$\leftarrow$",
         label="Large Cloud Providers",
-        zorder=12,
     )
     for label, x, y in zip(giant_labels, giant_cdf_data, giant_cum_weights):
         ax.annotate(
+            "",
+            (x, y),
+            textcoords="offset points",
+            xytext=(30, 10),  # Modify this to move tail around.
+            arrowprops={
+                "width": 4,
+                "headwidth": 16,
+                "facecolor": "blueviolet",
+                "edgecolor": "blueviolet",
+            },
+            zorder=12,
+        )
+        ax.annotate(
             label,
             (x, y),
-            c="purple",
             textcoords="offset points",
-            xytext=(-8, 10),  # Modify this to move text around.
-            ha="left",
+            xytext=(35, 0),  # Modify this to move text around.
             zorder=100,
         )
 


### PR DESCRIPTION
Close #137.

- `as_compatible_with_bgpq3` CSV file.
- Plot CDF of BGPq3-compatible/incompatible ASes with respect to all `aut-num`s.
- Scatter plot of Tier-1 ASes and large cloud providers (giants) on the CDF.
