### PR TITLE
Align "Export Self" (`spec_export_customers`) implementation w/ text

### DIFF
--- a/route_verification/bgp/src/cmp/filter.rs
+++ b/route_verification/bgp/src/cmp/filter.rs
@@ -98,14 +98,17 @@ impl<'a> CheckFilter<'a> {
             && self.cmp.verbosity.check_customer
             && num == self.self_num
             && op.permits(&self.cmp.prefix)
-            && self.is_accepting_customer()
+            && self.is_prev_as_customer()
     }
 
-    /// Check if the accepted ASN is in our customer set.
-    fn is_accepting_customer(&self) -> bool {
-        match self.query.as_sets.get(&customer_set(self.self_num)) {
-            None => false, // We don't have a customer set.
-            Some(customer_as_set) => customer_as_set.contains(&self.accept_num),
+    /// Check if the previous ASN on the AS path is in our customer set.
+    fn is_prev_as_customer(&self) -> bool {
+        match self.last_on_path() {
+            None => false, // Not a "received" route.
+            Some(prev_num) => match self.query.as_sets.get(&customer_set(self.self_num)) {
+                None => false, // No customer set.
+                Some(customer_as_set) => customer_as_set.contains(&prev_num),
+            },
         }
     }
 

--- a/route_verification/bgp/src/cmp/filter.rs
+++ b/route_verification/bgp/src/cmp/filter.rs
@@ -91,13 +91,22 @@ impl<'a> CheckFilter<'a> {
 
     /// Check for this case:
     /// - The AS number itself is the `<filter>`.
-    /// - Exporting customers routes.
+    /// - Exporting routes received from customers.
     #[inline]
     pub fn is_filter_export_customer(&self, num: u32, op: RangeOperator) -> bool {
         self.export
             && self.cmp.verbosity.check_customer
             && num == self.self_num
-            && self.filter_as_set(&customer_set(num), op).is_none()
+            && op.permits(&self.cmp.prefix)
+            && self.is_accepting_customer()
+    }
+
+    /// Check if the accepted ASN is in our customer set.
+    fn is_accepting_customer(&self) -> bool {
+        match self.query.as_sets.get(&customer_set(self.self_num)) {
+            None => false, // We don't have a customer set.
+            Some(customer_as_set) => customer_as_set.contains(&self.accept_num),
+        }
     }
 
     /// Check for this case:

--- a/route_verification/bgp/src/cmp/hill.rs
+++ b/route_verification/bgp/src/cmp/hill.rs
@@ -4,7 +4,7 @@ impl Compare {
     /// Same as [`check`](#method.check), except that AS Relationship DB `db` is used to
     /// convert suitable "bad" reports to "meh".
     /// - If `self.verbosity.show_meh` is `false`,
-    /// then these "meh" reports are removed.
+    ///     then these "meh" reports are removed.
     pub fn check_with_relationship(&self, query: &QueryIr, db: &AsRelDb) -> Vec<Report> {
         let mut reports = self.check(query);
         for report in reports.iter_mut() {

--- a/route_verification/bgp/src/query.rs
+++ b/route_verification/bgp/src/query.rs
@@ -9,7 +9,10 @@ pub use pseudo_set::*;
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct QueryAsSet {
     pub body: String,
+    /// Member ASNs.
     pub members: HashSet<u32>,
+    /// as-set members whose ASNs we don't know.
+    /// Empty if this is a customer pseudo set, since they have no set members.
     pub unrecorded_members: Vec<String>,
     pub is_any: bool,
 }
@@ -27,8 +30,8 @@ impl QueryAsSet {
 
 pub fn clean_vec<T: Ord>(v: &mut Vec<T>) {
     v.sort();
-    v.shrink_to_fit();
     v.dedup();
+    v.shrink_to_fit();
 }
 
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/route_verification/bgp/src/tests/psedo_set.rs
+++ b/route_verification/bgp/src/tests/psedo_set.rs
@@ -17,7 +17,7 @@ fn export_customers() -> Result<()> {
     };
     let cmp = Compare {
         prefix: "103.2.88.0/24".parse()?,
-        as_path: vec![Seq(139609), Seq(45891)],
+        as_path: vec![Seq(139609), Seq(45891), Seq(134525)],
         recursion_limit: 1,
         verbosity,
     };
@@ -28,6 +28,16 @@ fn export_customers() -> Result<()> {
 
 fn expected_reports_with_customers() -> Vec<Report> {
     vec![
+        UnrecExport {
+            from: 134525,
+            to: 45891,
+            items: vec![UnrecordedAutNum(134525)],
+        },
+        UnrecImport {
+            from: 134525,
+            to: 45891,
+            items: vec![UnrecordedAsSet("AS45891:AS-CUSTOMERS".into())],
+        },
         MehExport {
             from: 45891,
             to: 139609,


### PR DESCRIPTION
Instead of going through the customer cone, this implementation simply checks if the exported prefix is received from a customer AS.

Fix #124.

@cunha.